### PR TITLE
Fix async task connection isolation with per-task storage

### DIFF
--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -40,23 +40,26 @@ class DatabaseErrorWrapper(_DatabaseErrorWrapper):
 
 class _TaskAwareLocal:
     """
-    Connection storage that gives each async task its own connections.
+    Connection storage that isolates connections per ASGI request.
 
     In sync contexts, uses thread-local storage (same as Django).
-    In async contexts, uses a ContextVar keyed by asyncio.current_task()
-    so concurrent tasks on the same event loop thread each get their
-    own database connections.
+    In async contexts, uses a ContextVar so each ASGI request (which
+    runs in its own asyncio task) gets its own connection namespace.
+    Child tasks within a request share the parent's connection.
 
-    Django's default Local (from asgiref) with thread_critical=True stores
-    connections per-thread. Since all async tasks share one event loop
-    thread, they share one connection — corrupting transaction state
-    (in_atomic_block, savepoint_ids, needs_rollback) under concurrency.
+    Django's default Local (from asgiref) with thread_critical=True
+    stores connections per-thread. Since all async tasks share one
+    event loop thread, concurrent requests share one connection —
+    corrupting transaction state (in_atomic_block, savepoint_ids,
+    needs_rollback). This class fixes that by giving each request
+    its own namespace via ContextVar, while keeping child tasks on
+    the same connection to avoid pool exhaustion.
 
-    This class is a drop-in replacement: BaseConnectionHandler accesses
+    Drop-in replacement: BaseConnectionHandler accesses
     self._connections via getattr/setattr/delattr, all of which are
-    delegated to the per-task namespace. Connection aliases (e.g.
-    "default") are stored as attributes; internal state uses the "_"
-    prefix convention to avoid collision.
+    delegated to the namespace. Connection aliases (e.g. "default")
+    are stored as attributes; internal state uses the "_" prefix
+    convention to avoid collision.
     """
 
     def __init__(self):
@@ -71,13 +74,16 @@ class _TaskAwareLocal:
         if task is None:
             return self._thread_local
 
-        # Each task gets its own namespace. When asyncio.create_task()
-        # copies the parent context, the child inherits a reference to
-        # the parent's _TaskNamespace. The identity check detects this
-        # and creates a fresh namespace for the child, so connections
-        # are never shared across tasks.
+        # Child tasks created via asyncio.create_task() inherit the
+        # parent's ContextVar value, so they share the parent's
+        # connection namespace. This is intentional: per-request
+        # isolation comes from each ASGI request starting a fresh
+        # task with _task_connections=None. Within a request,
+        # child tasks share the connection to avoid pool exhaustion
+        # and to keep signal dispatch on the same connection.
+        # Use _independent_connection() for explicit parallelism.
         storage = _task_connections.get()
-        if storage is None or storage._task_ref is not task:
+        if storage is None:
             storage = _TaskNamespace(task)
             _task_connections.set(storage)
 

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -1,3 +1,7 @@
+import asyncio
+import threading
+from contextvars import ContextVar
+
 from asgiref.sync import iscoroutinefunction
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS
@@ -27,14 +31,85 @@ class DatabaseErrorWrapper(_DatabaseErrorWrapper):
         return inner
 
 
+class _TaskAwareLocal:
+    """
+    Connection storage that gives each async task its own connections.
+
+    In sync contexts, uses thread-local storage (same as Django).
+    In async contexts, uses a ContextVar keyed by asyncio.current_task()
+    so concurrent tasks on the same event loop thread each get their
+    own database connections.
+
+    Django's default Local (from asgiref) with thread_critical=True stores
+    connections per-thread. Since all async tasks share one event loop
+    thread, they share one connection — corrupting transaction state
+    (in_atomic_block, savepoint_ids, needs_rollback) under concurrency.
+
+    This class is a drop-in replacement: BaseConnectionHandler accesses
+    self._connections via getattr/setattr/delattr, all of which are
+    delegated to the per-task namespace. Connection aliases (e.g.
+    "default") are stored as attributes; internal state uses the "_"
+    prefix convention to avoid collision.
+    """
+
+    def __init__(self):
+        self._thread_local = threading.local()
+        self._task_connections = ContextVar(
+            "_task_connections", default=None
+        )
+
+    def _get_storage(self):
+        try:
+            task = asyncio.current_task()
+        except RuntimeError:
+            task = None
+
+        if task is None:
+            return self._thread_local
+
+        # Each task gets its own namespace. When asyncio.create_task()
+        # copies the parent context, the child inherits a reference to
+        # the parent's _TaskNamespace. The identity check detects this
+        # and creates a fresh namespace for the child, so connections
+        # are never shared across tasks.
+        storage = self._task_connections.get()
+        if storage is None or storage._task_ref is not task:
+            storage = _TaskNamespace(task)
+            self._task_connections.set(storage)
+
+        return storage
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._get_storage(), name)
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._get_storage(), name, value)
+
+    def __delattr__(self, name):
+        if name.startswith("_"):
+            object.__delattr__(self, name)
+        else:
+            delattr(self._get_storage(), name)
+
+
+class _TaskNamespace:
+    """Simple attribute namespace tied to a specific async task."""
+
+    def __init__(self, task):
+        self._task_ref = task
+
+
 class AsyncConnectionHandler(BaseAsyncConnectionHandler):
     settings_name = ConnectionHandler.settings_name
-    # Connections needs to still be an actual thread local, as it's truly
-    # thread-critical. Database backends should use @async_unsafe to protect
-    # their code from async contexts, but this will give those contexts
-    # separate connections in case it's needed as well. There's no cleanup
-    # after async contexts, though, so we don't allow that if we can help it.
-    thread_critical = True
+
+    def __init__(self, settings=None):
+        super().__init__(settings)
+        self._connections = _TaskAwareLocal()
 
     def configure_settings(self, databases):
         databases = super().configure_settings(databases)

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -1,7 +1,3 @@
-import asyncio
-import threading
-from contextvars import ContextVar
-
 from asgiref.sync import iscoroutinefunction
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS
@@ -10,13 +6,6 @@ from django.db.utils import DatabaseErrorWrapper as _DatabaseErrorWrapper
 from django.db.utils import load_backend
 
 from django_async_backend.utils.connection import BaseAsyncConnectionHandler
-
-# Module-level ContextVar for per-task connection storage. Must be
-# declared here (not inside a class or function) so that the same
-# ContextVar instance is used across all context copies created by
-# asyncio.create_task(). See aio-libs-abandoned/aioredis-py#1040
-# for what goes wrong when ContextVars are created per-instance.
-_task_connections = ContextVar("_task_connections", default=None)
 
 
 class DatabaseErrorWrapper(_DatabaseErrorWrapper):
@@ -38,88 +27,14 @@ class DatabaseErrorWrapper(_DatabaseErrorWrapper):
         return inner
 
 
-class _TaskAwareLocal:
-    """
-    Connection storage that isolates connections per ASGI request.
-
-    In sync contexts, uses thread-local storage (same as Django).
-    In async contexts, uses a ContextVar so each ASGI request (which
-    runs in its own asyncio task) gets its own connection namespace.
-    Child tasks within a request share the parent's connection.
-
-    Django's default Local (from asgiref) with thread_critical=True
-    stores connections per-thread. Since all async tasks share one
-    event loop thread, concurrent requests share one connection —
-    corrupting transaction state (in_atomic_block, savepoint_ids,
-    needs_rollback). This class fixes that by giving each request
-    its own namespace via ContextVar, while keeping child tasks on
-    the same connection to avoid pool exhaustion.
-
-    Drop-in replacement: BaseConnectionHandler accesses
-    self._connections via getattr/setattr/delattr, all of which are
-    delegated to the namespace. Connection aliases (e.g. "default")
-    are stored as attributes; internal state uses the "_" prefix
-    convention to avoid collision.
-    """
-
-    def __init__(self):
-        self._thread_local = threading.local()
-
-    def _get_storage(self):
-        try:
-            task = asyncio.current_task()
-        except RuntimeError:
-            task = None
-
-        if task is None:
-            return self._thread_local
-
-        # Child tasks created via asyncio.create_task() inherit the
-        # parent's ContextVar value, so they share the parent's
-        # connection namespace. This is intentional: per-request
-        # isolation comes from each ASGI request starting a fresh
-        # task with _task_connections=None. Within a request,
-        # child tasks share the connection to avoid pool exhaustion
-        # and to keep signal dispatch on the same connection.
-        # Use _independent_connection() for explicit parallelism.
-        storage = _task_connections.get()
-        if storage is None:
-            storage = _TaskNamespace(task)
-            _task_connections.set(storage)
-
-        return storage
-
-    def __getattr__(self, name):
-        if name.startswith("_"):
-            raise AttributeError(name)
-        return getattr(self._get_storage(), name)
-
-    def __setattr__(self, name, value):
-        if name.startswith("_"):
-            object.__setattr__(self, name, value)
-        else:
-            setattr(self._get_storage(), name, value)
-
-    def __delattr__(self, name):
-        if name.startswith("_"):
-            object.__delattr__(self, name)
-        else:
-            delattr(self._get_storage(), name)
-
-
-class _TaskNamespace:
-    """Simple attribute namespace tied to a specific async task."""
-
-    def __init__(self, task):
-        self._task_ref = task
-
-
 class AsyncConnectionHandler(BaseAsyncConnectionHandler):
     settings_name = ConnectionHandler.settings_name
-
-    def __init__(self, settings=None):
-        super().__init__(settings)
-        self._connections = _TaskAwareLocal()
+    # Connections needs to still be an actual thread local, as it's truly
+    # thread-critical. Database backends should use @async_unsafe to protect
+    # their code from async contexts, but this will give those contexts
+    # separate connections in case it's needed as well. There's no cleanup
+    # after async contexts, though, so we don't allow that if we can help it.
+    thread_critical = True
 
     def configure_settings(self, databases):
         databases = super().configure_settings(databases)

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -11,6 +11,13 @@ from django.db.utils import load_backend
 
 from django_async_backend.utils.connection import BaseAsyncConnectionHandler
 
+# Module-level ContextVar for per-task connection storage. Must be
+# declared here (not inside a class or function) so that the same
+# ContextVar instance is used across all context copies created by
+# asyncio.create_task(). See aio-libs-abandoned/aioredis-py#1040
+# for what goes wrong when ContextVars are created per-instance.
+_task_connections = ContextVar("_task_connections", default=None)
+
 
 class DatabaseErrorWrapper(_DatabaseErrorWrapper):
     def __call__(self, func):
@@ -54,9 +61,6 @@ class _TaskAwareLocal:
 
     def __init__(self):
         self._thread_local = threading.local()
-        self._task_connections = ContextVar(
-            "_task_connections", default=None
-        )
 
     def _get_storage(self):
         try:
@@ -72,10 +76,10 @@ class _TaskAwareLocal:
         # the parent's _TaskNamespace. The identity check detects this
         # and creates a fresh namespace for the child, so connections
         # are never shared across tasks.
-        storage = self._task_connections.get()
+        storage = _task_connections.get()
         if storage is None or storage._task_ref is not task:
             storage = _TaskNamespace(task)
-            self._task_connections.set(storage)
+            _task_connections.set(storage)
 
         return storage
 

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -1,0 +1,33 @@
+import asyncio
+
+from django.utils.decorators import sync_and_async_middleware
+
+from django_async_backend.db import async_connections
+
+
+@sync_and_async_middleware
+def close_async_connections(get_response):
+    """Close async DB connections after each request.
+
+    Django's request_finished signal closes sync connections, but
+    async_connections needs its own cleanup to return connections
+    to the pool. Add this to MIDDLEWARE when using ASGI:
+
+        MIDDLEWARE = [
+            "django_async_backend.middleware.close_async_connections",
+            ...
+        ]
+    """
+    if asyncio.iscoroutinefunction(get_response):
+
+        async def middleware(request):
+            response = await get_response(request)
+            await async_connections.close_all()
+            return response
+
+    else:
+
+        def middleware(request):
+            return get_response(request)
+
+    return middleware

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -21,9 +21,10 @@ def close_async_connections(get_response):
     if asyncio.iscoroutinefunction(get_response):
 
         async def middleware(request):
-            response = await get_response(request)
-            await async_connections.close_all()
-            return response
+            try:
+                return await get_response(request)
+            finally:
+                await async_connections.close_all()
 
     else:
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,235 @@
+"""
+Tests for concurrent async task safety.
+
+These tests verify that async_connections and async_atomic work correctly
+when multiple asyncio tasks run concurrently on the same event loop thread.
+
+Root cause under test: AsyncConnectionHandler uses thread_critical=True,
+making connections thread-local. Since all async tasks share one event loop
+thread, they share one connection object. Transaction state (in_atomic_block,
+savepoint_ids, needs_rollback) gets corrupted when tasks overlap.
+
+See: https://github.com/Arfey/django-async-backend/issues/11
+"""
+
+import asyncio
+
+from django.db import DEFAULT_DB_ALIAS
+
+from django_async_backend.db import async_connections
+from django_async_backend.db.transaction import async_atomic
+from django_async_backend.test import AsyncioTransactionTestCase
+
+N_TASKS = 10
+
+
+async def create_table():
+    async with await async_connections[DEFAULT_DB_ALIAS].cursor() as cursor:
+        await cursor.execute(
+            """
+            CREATE TABLE concurrency_test (
+                id SERIAL PRIMARY KEY,
+                task_id INTEGER NOT NULL
+            );
+            """
+        )
+
+
+async def drop_table():
+    async with await async_connections[DEFAULT_DB_ALIAS].cursor() as cursor:
+        await cursor.execute("DROP TABLE IF EXISTS concurrency_test;")
+
+    await async_connections[DEFAULT_DB_ALIAS].close()
+
+
+async def count_rows():
+    async with await async_connections[DEFAULT_DB_ALIAS].cursor() as cursor:
+        res = await cursor.execute(
+            "SELECT COUNT(*) FROM concurrency_test;"
+        )
+        row = await res.fetchone()
+        return row[0]
+
+
+class ConcurrentAtomicWriteTests(AsyncioTransactionTestCase):
+    """
+    Multiple async tasks each open their own async_atomic() block and
+    INSERT a row. With proper task isolation, all N tasks should succeed
+    independently. With shared connections, savepoint IDs collide and
+    transactions abort.
+    """
+
+    async def asyncSetUp(self):
+        await create_table()
+
+    async def asyncTearDown(self):
+        await drop_table()
+
+    async def test_concurrent_atomic_writes(self):
+        """N concurrent async_atomic writes should all succeed."""
+        barrier = asyncio.Barrier(N_TASKS)
+        errors = []
+
+        async def writer(task_id):
+            try:
+                # Barrier ensures all tasks enter async_atomic before
+                # any proceeds, maximizing interleaving.
+                await barrier.wait()
+                async with async_atomic():
+                    async with await async_connections[
+                        DEFAULT_DB_ALIAS
+                    ].cursor() as cursor:
+                        await cursor.execute(
+                            "INSERT INTO concurrency_test (task_id) "
+                            "VALUES (%s);",
+                            [task_id],
+                        )
+                    # Yield to other tasks inside the atomic block.
+                    await asyncio.sleep(0)
+            except Exception as e:
+                errors.append((task_id, e))
+
+        await asyncio.gather(*(writer(i) for i in range(N_TASKS)))
+
+        self.assertEqual(
+            errors,
+            [],
+            f"{len(errors)}/{N_TASKS} tasks failed: "
+            + "; ".join(f"task {tid}: {e}" for tid, e in errors),
+        )
+
+        row_count = await count_rows()
+        self.assertEqual(row_count, N_TASKS)
+
+
+class ConcurrentReadTests(AsyncioTransactionTestCase):
+    """
+    Multiple async tasks each run a SELECT COUNT concurrently.
+    With proper task isolation, all should return the correct count.
+    With shared connections, reads can see corrupted transaction state.
+    """
+
+    async def asyncSetUp(self):
+        await create_table()
+        # Seed rows for reading.
+        async with await async_connections[
+            DEFAULT_DB_ALIAS
+        ].cursor() as cursor:
+            for i in range(5):
+                await cursor.execute(
+                    "INSERT INTO concurrency_test (task_id) VALUES (%s);",
+                    [i],
+                )
+
+    async def asyncTearDown(self):
+        await drop_table()
+
+    async def test_concurrent_reads(self):
+        """N concurrent reads should all return the correct count."""
+        barrier = asyncio.Barrier(N_TASKS)
+        results = []
+        errors = []
+
+        async def reader(task_id):
+            try:
+                await barrier.wait()
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as cursor:
+                    res = await cursor.execute(
+                        "SELECT COUNT(*) FROM concurrency_test;"
+                    )
+                    row = await res.fetchone()
+                    results.append((task_id, row[0]))
+                    await asyncio.sleep(0)
+            except Exception as e:
+                errors.append((task_id, e))
+
+        await asyncio.gather(*(reader(i) for i in range(N_TASKS)))
+
+        self.assertEqual(
+            errors,
+            [],
+            f"{len(errors)}/{N_TASKS} readers failed: "
+            + "; ".join(f"task {tid}: {e}" for tid, e in errors),
+        )
+
+        self.assertEqual(len(results), N_TASKS)
+        for task_id, count in results:
+            self.assertEqual(
+                count,
+                5,
+                f"Task {task_id} got count={count}, expected 5",
+            )
+
+
+class ConcurrentMixedReadWriteTests(AsyncioTransactionTestCase):
+    """
+    Concurrent mix of writers (async_atomic + INSERT) and readers (SELECT).
+    Writers should all succeed and readers should get consistent results.
+    """
+
+    async def asyncSetUp(self):
+        await create_table()
+
+    async def asyncTearDown(self):
+        await drop_table()
+
+    async def test_concurrent_mixed(self):
+        """Concurrent readers and writers should not interfere."""
+        n_writers = 10
+        n_readers = 10
+        write_barrier = asyncio.Barrier(n_writers)
+        read_barrier = asyncio.Barrier(n_readers)
+        write_errors = []
+        read_errors = []
+
+        async def writer(task_id):
+            try:
+                await write_barrier.wait()
+                async with async_atomic():
+                    async with await async_connections[
+                        DEFAULT_DB_ALIAS
+                    ].cursor() as cursor:
+                        await cursor.execute(
+                            "INSERT INTO concurrency_test (task_id) "
+                            "VALUES (%s);",
+                            [task_id],
+                        )
+                    await asyncio.sleep(0)
+            except Exception as e:
+                write_errors.append((task_id, e))
+
+        async def reader(task_id):
+            try:
+                await read_barrier.wait()
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as cursor:
+                    res = await cursor.execute(
+                        "SELECT COUNT(*) FROM concurrency_test;"
+                    )
+                    await res.fetchone()
+                    await asyncio.sleep(0)
+            except Exception as e:
+                read_errors.append((task_id, e))
+
+        tasks = [writer(i) for i in range(n_writers)]
+        tasks += [reader(i) for i in range(n_readers)]
+        await asyncio.gather(*tasks)
+
+        self.assertEqual(
+            write_errors,
+            [],
+            f"{len(write_errors)}/{n_writers} writers failed: "
+            + "; ".join(f"task {tid}: {e}" for tid, e in write_errors),
+        )
+        self.assertEqual(
+            read_errors,
+            [],
+            f"{len(read_errors)}/{n_readers} readers failed: "
+            + "; ".join(f"task {tid}: {e}" for tid, e in read_errors),
+        )
+
+        row_count = await count_rows()
+        self.assertEqual(row_count, n_writers)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,13 +1,16 @@
 """
 Tests for concurrent async task safety.
 
-These tests verify that async_connections correctly isolates connections
-per ASGI request while sharing connections within a request's child tasks.
+Demonstrates the INTRANS bug: child tasks sharing a connection via
+ContextVar inheritance each open their own async_atomic(), creating
+overlapping savepoints that corrupt transaction state.
 
-Bug fixed: AsyncConnectionHandler used thread_critical=True, making
-connections thread-local. Since all async tasks share one event loop
-thread, concurrent requests shared one connection, corrupting transaction
-state. The fix uses a ContextVar so each request gets its own namespace.
+    ProgrammingError: can't change 'autocommit' now:
+        connection in transaction status INTRANS
+
+Correct patterns:
+  1. Single parent async_atomic() wrapping asyncio.gather()
+  2. _independent_connection() for per-task isolation
 
 See: https://github.com/Arfey/django-async-backend/issues/11
 """
@@ -25,6 +28,9 @@ N_TASKS = 10
 
 async def create_table():
     async with await async_connections[DEFAULT_DB_ALIAS].cursor() as cursor:
+        await cursor.execute(
+            "DROP TABLE IF EXISTS concurrency_test;"
+        )
         await cursor.execute(
             """
             CREATE TABLE concurrency_test (
@@ -51,11 +57,17 @@ async def count_rows():
         return row[0]
 
 
-class ConcurrentAtomicWriteTests(AsyncioTransactionTestCase):
+class PerTaskAtomicBugTests(AsyncioTransactionTestCase):
     """
-    A parent task opens async_atomic, then child tasks INSERT rows
-    using the shared connection. All writes happen on the parent's
-    transaction. This matches Arfey's recommended pattern.
+    Proves the INTRANS bug: concurrent child tasks each opening their
+    own async_atomic() on a shared connection corrupt transaction state.
+
+    This is the pattern from issue #11. Child tasks inherit the parent's
+    connection via ContextVar. When each child calls async_atomic(),
+    they create overlapping savepoints on the same connection, leading to:
+
+        ProgrammingError: can't change 'autocommit' now:
+            connection in transaction status INTRANS
     """
 
     async def asyncSetUp(self):
@@ -64,8 +76,67 @@ class ConcurrentAtomicWriteTests(AsyncioTransactionTestCase):
     async def asyncTearDown(self):
         await drop_table()
 
-    async def test_concurrent_writes_in_parent_transaction(self):
-        """Parent opens transaction, child tasks write on shared connection."""
+    async def test_per_task_atomic_causes_intrans(self):
+        """Each child task opening async_atomic() triggers INTRANS.
+
+        Run multiple rounds to defeat timing flakiness — the bug
+        depends on task interleaving so a single round can
+        occasionally succeed by luck.
+        """
+        rounds = 5
+        all_errors = []
+
+        for _ in range(rounds):
+            barrier = asyncio.Barrier(N_TASKS)
+            errors = []
+
+            async def writer(task_id):
+                try:
+                    await barrier.wait()
+                    async with async_atomic():
+                        async with await async_connections[
+                            DEFAULT_DB_ALIAS
+                        ].cursor() as cursor:
+                            await cursor.execute(
+                                "INSERT INTO concurrency_test "
+                                "(task_id) VALUES (%s);",
+                                [task_id],
+                            )
+                        await asyncio.sleep(0)
+                except Exception as e:
+                    errors.append((task_id, e))
+
+            await asyncio.gather(
+                *(writer(i) for i in range(N_TASKS))
+            )
+            all_errors.extend(errors)
+            if errors:
+                break  # Bug triggered, no need for more rounds
+
+        self.assertTrue(
+            len(all_errors) > 0,
+            f"Expected INTRANS errors from overlapping per-task "
+            f"async_atomic() on shared connection, but got none "
+            f"after {rounds} rounds. "
+            f"If this fails, the bug may be fixed upstream.",
+        )
+
+
+class ParentAtomicPatternTests(AsyncioTransactionTestCase):
+    """
+    Correct pattern: single parent async_atomic() wrapping
+    asyncio.gather(). Child tasks write on the parent's transaction.
+    No per-task savepoints, no INTRANS.
+    """
+
+    async def asyncSetUp(self):
+        await create_table()
+
+    async def asyncTearDown(self):
+        await drop_table()
+
+    async def test_parent_atomic_with_child_writes(self):
+        """Parent opens transaction, child tasks write. All succeed."""
         barrier = asyncio.Barrier(N_TASKS)
         errors = []
 
@@ -98,153 +169,54 @@ class ConcurrentAtomicWriteTests(AsyncioTransactionTestCase):
         self.assertEqual(row_count, N_TASKS)
 
 
-class ConcurrentReadTests(AsyncioTransactionTestCase):
+class IndependentConnectionTests(AsyncioTransactionTestCase):
     """
-    Multiple async tasks each run a SELECT COUNT concurrently.
-    Child tasks share the parent's connection and execute serially.
+    Correct pattern: _independent_connection() gives each child task
+    its own connection, so per-task async_atomic() works safely.
     """
 
     async def asyncSetUp(self):
         await create_table()
-        # Seed rows for reading.
-        async with await async_connections[
-            DEFAULT_DB_ALIAS
-        ].cursor() as cursor:
-            for i in range(5):
-                await cursor.execute(
-                    "INSERT INTO concurrency_test (task_id) VALUES (%s);",
-                    [i],
-                )
 
     async def asyncTearDown(self):
         await drop_table()
 
-    async def test_concurrent_reads(self):
-        """N concurrent reads should all return the correct count."""
+    async def test_independent_connections_with_per_task_atomic(self):
+        """Each task gets its own connection via _independent_connection."""
         barrier = asyncio.Barrier(N_TASKS)
-        results = []
         errors = []
 
-        async def reader(task_id):
+        async def writer(task_id):
             try:
                 await barrier.wait()
-                async with await async_connections[
-                    DEFAULT_DB_ALIAS
-                ].cursor() as cursor:
-                    res = await cursor.execute(
-                        "SELECT COUNT(*) FROM concurrency_test;"
-                    )
-                    row = await res.fetchone()
-                    results.append((task_id, row[0]))
-                    await asyncio.sleep(0)
+                async with async_connections._independent_connection():
+                    async with async_atomic():
+                        async with await async_connections[
+                            DEFAULT_DB_ALIAS
+                        ].cursor() as cursor:
+                            await cursor.execute(
+                                "INSERT INTO concurrency_test "
+                                "(task_id) VALUES (%s);",
+                                [task_id],
+                            )
+                        await asyncio.sleep(0)
             except Exception as e:
                 errors.append((task_id, e))
 
-        await asyncio.gather(*(reader(i) for i in range(N_TASKS)))
+        await asyncio.gather(*(writer(i) for i in range(N_TASKS)))
 
         self.assertEqual(
             errors,
             [],
-            f"{len(errors)}/{N_TASKS} readers failed: "
+            f"{len(errors)}/{N_TASKS} tasks failed: "
             + "; ".join(f"task {tid}: {e}" for tid, e in errors),
         )
 
-        self.assertEqual(len(results), N_TASKS)
-        for task_id, count in results:
-            self.assertEqual(
-                count,
-                5,
-                f"Task {task_id} got count={count}, expected 5",
-            )
-
-
-class ConcurrentMixedReadWriteTests(AsyncioTransactionTestCase):
-    """
-    Concurrent mix of writers (INSERT, no per-task transaction) and
-    readers (SELECT) sharing the parent's connection.
-    """
-
-    async def asyncSetUp(self):
-        await create_table()
-
-    async def asyncTearDown(self):
-        await drop_table()
-
-    async def test_concurrent_mixed(self):
-        """Concurrent readers and writers should not interfere."""
-        n_writers = 10
-        n_readers = 10
-        write_barrier = asyncio.Barrier(n_writers)
-        read_barrier = asyncio.Barrier(n_readers)
-        write_errors = []
-        read_errors = []
-
-        async def writer(task_id):
-            try:
-                await write_barrier.wait()
-                async with await async_connections[
-                    DEFAULT_DB_ALIAS
-                ].cursor() as cursor:
-                    await cursor.execute(
-                        "INSERT INTO concurrency_test (task_id) "
-                        "VALUES (%s);",
-                        [task_id],
-                    )
-                await asyncio.sleep(0)
-            except Exception as e:
-                write_errors.append((task_id, e))
-
-        async def reader(task_id):
-            try:
-                await read_barrier.wait()
-                async with await async_connections[
-                    DEFAULT_DB_ALIAS
-                ].cursor() as cursor:
-                    res = await cursor.execute(
-                        "SELECT COUNT(*) FROM concurrency_test;"
-                    )
-                    await res.fetchone()
-                    await asyncio.sleep(0)
-            except Exception as e:
-                read_errors.append((task_id, e))
-
-        tasks = [writer(i) for i in range(n_writers)]
-        tasks += [reader(i) for i in range(n_readers)]
-        await asyncio.gather(*tasks)
-
-        self.assertEqual(
-            write_errors,
-            [],
-            f"{len(write_errors)}/{n_writers} writers failed: "
-            + "; ".join(f"task {tid}: {e}" for tid, e in write_errors),
-        )
-        self.assertEqual(
-            read_errors,
-            [],
-            f"{len(read_errors)}/{n_readers} readers failed: "
-            + "; ".join(f"task {tid}: {e}" for tid, e in read_errors),
-        )
-
         row_count = await count_rows()
-        self.assertEqual(row_count, n_writers)
+        self.assertEqual(row_count, N_TASKS)
 
-
-class TaskIsolationTests(AsyncioTransactionTestCase):
-    """
-    Verify that child tasks share the parent's connection (not isolated).
-    This is intentional: per-request isolation comes from ASGI creating
-    a fresh task per request. Within a request, child tasks share the
-    parent's connection to avoid pool exhaustion.
-    """
-
-    async def asyncSetUp(self):
-        await create_table()
-
-    async def asyncTearDown(self):
-        await drop_table()
-
-    async def test_parent_child_share_connection(self):
-        """Child task via create_task shares parent's connection."""
+    async def test_independent_connection_is_different_object(self):
+        """_independent_connection provides a distinct connection."""
         parent_conn = async_connections[DEFAULT_DB_ALIAS]
         await parent_conn.ensure_connection()
         parent_id = id(parent_conn)
@@ -252,41 +224,18 @@ class TaskIsolationTests(AsyncioTransactionTestCase):
         child_ids = []
 
         async def child():
-            conn = async_connections[DEFAULT_DB_ALIAS]
-            await conn.ensure_connection()
-            child_ids.append(id(conn))
-
-        task = asyncio.create_task(child())
-        await task
-
-        self.assertEqual(len(child_ids), 1)
-        self.assertEqual(
-            parent_id,
-            child_ids[0],
-            "Child task got a different connection than parent — "
-            "child tasks should share the parent's connection",
-        )
-
-    async def test_independent_connection_workaround(self):
-        """Child task with _independent_connection gets its own connection."""
-        parent_conn = async_connections[DEFAULT_DB_ALIAS]
-        await parent_conn.ensure_connection()
-        parent_id = id(parent_conn)
-
-        child_ids = []
-
-        async def child_with_independent_conn():
             async with async_connections._independent_connection():
                 conn = async_connections[DEFAULT_DB_ALIAS]
                 await conn.ensure_connection()
                 child_ids.append(id(conn))
 
-        task = asyncio.create_task(child_with_independent_conn())
+        task = asyncio.create_task(child())
         await task
 
         self.assertEqual(len(child_ids), 1)
         self.assertNotEqual(
             parent_id,
             child_ids[0],
-            "_independent_connection should provide a different connection",
+            "_independent_connection should provide a "
+            "different connection",
         )

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,12 +1,19 @@
 """
 Tests for concurrent async task safety.
 
-Demonstrates the INTRANS bug: child tasks sharing a connection via
-ContextVar inheritance each open their own async_atomic(), creating
-overlapping savepoints that corrupt transaction state.
+Two bugs:
 
-    ProgrammingError: can't change 'autocommit' now:
-        connection in transaction status INTRANS
+1. Pool exhaustion (PoolExhaustionTests): ASGI has no equivalent of
+   Django's close_old_connections signal. Without middleware calling
+   close_all(), each request leaks a connection that is never returned
+   to the pool.
+
+2. Transaction corruption (PerTaskAtomicBugTests): child tasks sharing
+   a connection via ContextVar inheritance each open their own
+   async_atomic(), creating overlapping savepoints:
+
+       ProgrammingError: can't change 'autocommit' now:
+           connection in transaction status INTRANS
 
 Correct patterns:
   1. Single parent async_atomic() wrapping asyncio.gather()
@@ -16,6 +23,7 @@ See: https://github.com/Arfey/django-async-backend/issues/11
 """
 
 import asyncio
+import contextvars
 
 from django.db import DEFAULT_DB_ALIAS
 
@@ -55,6 +63,85 @@ async def count_rows():
         )
         row = await res.fetchone()
         return row[0]
+
+
+async def count_pg_backends():
+    """Count other connections to this database in pg_stat_activity."""
+    async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+        res = await c.execute(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE datname = current_database() "
+            "AND pid != pg_backend_pid()"
+        )
+        row = await res.fetchone()
+        return row[0]
+
+
+class PoolExhaustionTests(AsyncioTransactionTestCase):
+    """
+    Without close_all() after each request, connections are never
+    returned to the pool. Each ASGI request gets a fresh ContextVar
+    context, creates a new connection, and abandons it when done.
+
+    The close_async_connections middleware fixes this by calling
+    close_all() after each response.
+    """
+
+    async def test_connections_leak_without_cleanup(self):
+        """Simulated requests without close_all leak connections."""
+        baseline = await count_pg_backends()
+
+        n_requests = 20
+        for _ in range(n_requests):
+
+            async def fake_request():
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as c:
+                    await c.execute("SELECT 1")
+
+            await asyncio.create_task(
+                fake_request(), context=contextvars.Context()
+            )
+
+        after = await count_pg_backends()
+        leaked = after - baseline
+        # May be capped by pool max_size or pg max_connections,
+        # but should be substantial (most of n_requests).
+        self.assertGreaterEqual(
+            leaked,
+            n_requests // 2,
+            f"Expected many leaked connections, got {leaked}. "
+            f"Each ASGI request without close_all() leaks one "
+            f"(may be capped by pool or pg limits).",
+        )
+
+    async def test_connections_returned_with_cleanup(self):
+        """Simulated requests with close_all return connections."""
+        baseline = await count_pg_backends()
+
+        n_requests = 20
+        for _ in range(n_requests):
+
+            async def fake_request():
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as c:
+                    await c.execute("SELECT 1")
+                await async_connections.close_all()
+
+            await asyncio.create_task(
+                fake_request(), context=contextvars.Context()
+            )
+
+        after = await count_pg_backends()
+        leaked = after - baseline
+        self.assertLessEqual(
+            leaked,
+            2,
+            f"Expected ~0 leaked connections with cleanup, "
+            f"got {leaked}.",
+        )
 
 
 class PerTaskAtomicBugTests(AsyncioTransactionTestCase):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,13 +1,13 @@
 """
 Tests for concurrent async task safety.
 
-These tests verify that async_connections and async_atomic work correctly
-when multiple asyncio tasks run concurrently on the same event loop thread.
+These tests verify that async_connections correctly isolates connections
+per ASGI request while sharing connections within a request's child tasks.
 
-Root cause under test: AsyncConnectionHandler uses thread_critical=True,
-making connections thread-local. Since all async tasks share one event loop
-thread, they share one connection object. Transaction state (in_atomic_block,
-savepoint_ids, needs_rollback) gets corrupted when tasks overlap.
+Bug fixed: AsyncConnectionHandler used thread_critical=True, making
+connections thread-local. Since all async tasks share one event loop
+thread, concurrent requests shared one connection, corrupting transaction
+state. The fix uses a ContextVar so each request gets its own namespace.
 
 See: https://github.com/Arfey/django-async-backend/issues/11
 """
@@ -53,10 +53,9 @@ async def count_rows():
 
 class ConcurrentAtomicWriteTests(AsyncioTransactionTestCase):
     """
-    Multiple async tasks each open their own async_atomic() block and
-    INSERT a row. With proper task isolation, all N tasks should succeed
-    independently. With shared connections, savepoint IDs collide and
-    transactions abort.
+    A parent task opens async_atomic, then child tasks INSERT rows
+    using the shared connection. All writes happen on the parent's
+    transaction. This matches Arfey's recommended pattern.
     """
 
     async def asyncSetUp(self):
@@ -65,31 +64,28 @@ class ConcurrentAtomicWriteTests(AsyncioTransactionTestCase):
     async def asyncTearDown(self):
         await drop_table()
 
-    async def test_concurrent_atomic_writes(self):
-        """N concurrent async_atomic writes should all succeed."""
+    async def test_concurrent_writes_in_parent_transaction(self):
+        """Parent opens transaction, child tasks write on shared connection."""
         barrier = asyncio.Barrier(N_TASKS)
         errors = []
 
         async def writer(task_id):
             try:
-                # Barrier ensures all tasks enter async_atomic before
-                # any proceeds, maximizing interleaving.
                 await barrier.wait()
-                async with async_atomic():
-                    async with await async_connections[
-                        DEFAULT_DB_ALIAS
-                    ].cursor() as cursor:
-                        await cursor.execute(
-                            "INSERT INTO concurrency_test (task_id) "
-                            "VALUES (%s);",
-                            [task_id],
-                        )
-                    # Yield to other tasks inside the atomic block.
-                    await asyncio.sleep(0)
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as cursor:
+                    await cursor.execute(
+                        "INSERT INTO concurrency_test (task_id) "
+                        "VALUES (%s);",
+                        [task_id],
+                    )
+                await asyncio.sleep(0)
             except Exception as e:
                 errors.append((task_id, e))
 
-        await asyncio.gather(*(writer(i) for i in range(N_TASKS)))
+        async with async_atomic():
+            await asyncio.gather(*(writer(i) for i in range(N_TASKS)))
 
         self.assertEqual(
             errors,
@@ -105,8 +101,7 @@ class ConcurrentAtomicWriteTests(AsyncioTransactionTestCase):
 class ConcurrentReadTests(AsyncioTransactionTestCase):
     """
     Multiple async tasks each run a SELECT COUNT concurrently.
-    With proper task isolation, all should return the correct count.
-    With shared connections, reads can see corrupted transaction state.
+    Child tasks share the parent's connection and execute serially.
     """
 
     async def asyncSetUp(self):
@@ -165,8 +160,8 @@ class ConcurrentReadTests(AsyncioTransactionTestCase):
 
 class ConcurrentMixedReadWriteTests(AsyncioTransactionTestCase):
     """
-    Concurrent mix of writers (async_atomic + INSERT) and readers (SELECT).
-    Writers should all succeed and readers should get consistent results.
+    Concurrent mix of writers (INSERT, no per-task transaction) and
+    readers (SELECT) sharing the parent's connection.
     """
 
     async def asyncSetUp(self):
@@ -187,16 +182,15 @@ class ConcurrentMixedReadWriteTests(AsyncioTransactionTestCase):
         async def writer(task_id):
             try:
                 await write_barrier.wait()
-                async with async_atomic():
-                    async with await async_connections[
-                        DEFAULT_DB_ALIAS
-                    ].cursor() as cursor:
-                        await cursor.execute(
-                            "INSERT INTO concurrency_test (task_id) "
-                            "VALUES (%s);",
-                            [task_id],
-                        )
-                    await asyncio.sleep(0)
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as cursor:
+                    await cursor.execute(
+                        "INSERT INTO concurrency_test (task_id) "
+                        "VALUES (%s);",
+                        [task_id],
+                    )
+                await asyncio.sleep(0)
             except Exception as e:
                 write_errors.append((task_id, e))
 
@@ -237,9 +231,10 @@ class ConcurrentMixedReadWriteTests(AsyncioTransactionTestCase):
 
 class TaskIsolationTests(AsyncioTransactionTestCase):
     """
-    Verify that parent and child tasks get separate connections.
-    This directly exercises the _TaskAwareLocal identity check that
-    detects inherited ContextVar values from asyncio.create_task().
+    Verify that child tasks share the parent's connection (not isolated).
+    This is intentional: per-request isolation comes from ASGI creating
+    a fresh task per request. Within a request, child tasks share the
+    parent's connection to avoid pool exhaustion.
     """
 
     async def asyncSetUp(self):
@@ -248,8 +243,8 @@ class TaskIsolationTests(AsyncioTransactionTestCase):
     async def asyncTearDown(self):
         await drop_table()
 
-    async def test_parent_child_task_isolation(self):
-        """Child task via create_task gets its own connection."""
+    async def test_parent_child_share_connection(self):
+        """Child task via create_task shares parent's connection."""
         parent_conn = async_connections[DEFAULT_DB_ALIAS]
         await parent_conn.ensure_connection()
         parent_id = id(parent_conn)
@@ -265,9 +260,33 @@ class TaskIsolationTests(AsyncioTransactionTestCase):
         await task
 
         self.assertEqual(len(child_ids), 1)
+        self.assertEqual(
+            parent_id,
+            child_ids[0],
+            "Child task got a different connection than parent — "
+            "child tasks should share the parent's connection",
+        )
+
+    async def test_independent_connection_workaround(self):
+        """Child task with _independent_connection gets its own connection."""
+        parent_conn = async_connections[DEFAULT_DB_ALIAS]
+        await parent_conn.ensure_connection()
+        parent_id = id(parent_conn)
+
+        child_ids = []
+
+        async def child_with_independent_conn():
+            async with async_connections._independent_connection():
+                conn = async_connections[DEFAULT_DB_ALIAS]
+                await conn.ensure_connection()
+                child_ids.append(id(conn))
+
+        task = asyncio.create_task(child_with_independent_conn())
+        await task
+
+        self.assertEqual(len(child_ids), 1)
         self.assertNotEqual(
             parent_id,
             child_ids[0],
-            "Child task got the same connection as parent — "
-            "task isolation is broken",
+            "_independent_connection should provide a different connection",
         )

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -233,3 +233,41 @@ class ConcurrentMixedReadWriteTests(AsyncioTransactionTestCase):
 
         row_count = await count_rows()
         self.assertEqual(row_count, n_writers)
+
+
+class TaskIsolationTests(AsyncioTransactionTestCase):
+    """
+    Verify that parent and child tasks get separate connections.
+    This directly exercises the _TaskAwareLocal identity check that
+    detects inherited ContextVar values from asyncio.create_task().
+    """
+
+    async def asyncSetUp(self):
+        await create_table()
+
+    async def asyncTearDown(self):
+        await drop_table()
+
+    async def test_parent_child_task_isolation(self):
+        """Child task via create_task gets its own connection."""
+        parent_conn = async_connections[DEFAULT_DB_ALIAS]
+        await parent_conn.ensure_connection()
+        parent_id = id(parent_conn)
+
+        child_ids = []
+
+        async def child():
+            conn = async_connections[DEFAULT_DB_ALIAS]
+            await conn.ensure_connection()
+            child_ids.append(id(conn))
+
+        task = asyncio.create_task(child())
+        await task
+
+        self.assertEqual(len(child_ids), 1)
+        self.assertNotEqual(
+            parent_id,
+            child_ids[0],
+            "Child task got the same connection as parent — "
+            "task isolation is broken",
+        )


### PR DESCRIPTION
Fixes https://github.com/Arfey/django-async-backend/issues/11

Concurrent async tasks, with a shared connection, corrupts state. As seen in the test. This fix addresses it via _TaskAwareLocal which replaces Local(thread_critical=True). I use ContextVar + a task identity check. And a Middleware: close_async_connections returns connections to pool at request end. This is a stopgap until django/django#20288 lands signal-based cleanup. Without this middleware, we cannot perform reasonable testing in Django 6.0.
  
Alignment with DEP 0009: two isolation levels:
- Per-request (automatic via _TaskAwareLocal - ASGI handler creates task per request)
- Within-request parallelism (explicit via _independent_connection, now concurrency-safe)
  
 Question: should _independent_connection be renamed to new_connections per DEP 0009?

# Process

Claude was used to develop and test this fix. All code was reviewed by me. I tried to respect DEP 0009 in my changes. I also performed a deeper benchmark (Happy to contribute that but out of scope of this fix) to help test performance and correctness at scale. I found significantly more RPS with significantly less ram vs WSGI all-sync. I forced a small DB latency to make it a realistic workload. I'd be happy to share but posting big numbers now is worthless as we can basically make them whatever want by adjusting the simulated SQL latency.

## Summary by Sourcery

Ensure async database connections are isolated per asyncio task and cleaned up after each ASGI request to prevent state corruption under concurrent async workloads.

Bug Fixes:
- Isolate async database connections per asyncio task instead of per thread to prevent transaction state corruption when tasks run concurrently on the same event loop thread.

Enhancements:
- Introduce a task-aware connection storage implementation used by AsyncConnectionHandler to align async connection handling with per-request and within-request parallelism semantics.

Documentation:
- Document middleware usage for closing async database connections after each request in ASGI deployments.

Tests:
- Add concurrency-focused async tests covering concurrent writes, reads, and mixed read/write workloads to validate task-level connection isolation.