### PR TITLE
Add close_async_connections middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ INSTALLED_APPS = [
 
 ---
 
+## Middleware
+
+When running under ASGI, add `close_async_connections` to `MIDDLEWARE` so connections are returned to the pool at the end of each request. Django's `request_finished` signal only closes sync connections.
+
+```python
+MIDDLEWARE = [
+    "django_async_backend.middleware.close_async_connections",
+    ...
+]
+```
+
+---
+
 ## Connection Handler
 
 The connection handler manages database connections for your async backend.

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -1,11 +1,11 @@
 import asyncio
 
-from django.utils.decorators import sync_and_async_middleware
+from django.utils.decorators import async_only_middleware
 
 from django_async_backend.db import async_connections
 
 
-@sync_and_async_middleware
+@async_only_middleware
 def close_async_connections(get_response):
     """Close async DB connections after each request.
 
@@ -18,17 +18,11 @@ def close_async_connections(get_response):
             ...
         ]
     """
-    if asyncio.iscoroutinefunction(get_response):
 
-        async def middleware(request):
-            try:
-                return await get_response(request)
-            finally:
-                await async_connections.close_all()
-
-    else:
-
-        def middleware(request):
-            return get_response(request)
+    async def middleware(request):
+        try:
+            return await get_response(request)
+        finally:
+            await asyncio.shield(async_connections.close_all())
 
     return middleware

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from django.utils.decorators import sync_and_async_middleware
+
+from django_async_backend.db import async_connections
+
+
+@sync_and_async_middleware
+def close_async_connections(get_response):
+    """Close async DB connections after each request.
+
+    Django's request_finished signal closes sync connections, but
+    async_connections needs its own cleanup to return connections
+    to the pool. Add this to MIDDLEWARE when using ASGI:
+
+        MIDDLEWARE = [
+            "django_async_backend.middleware.close_async_connections",
+            ...
+        ]
+    """
+    if asyncio.iscoroutinefunction(get_response):
+
+        async def middleware(request):
+            try:
+                return await get_response(request)
+            finally:
+                await async_connections.close_all()
+
+    else:
+
+        def middleware(request):
+            return get_response(request)
+
+    return middleware

--- a/tests/utils/test_connection.py
+++ b/tests/utils/test_connection.py
@@ -1,15 +1,11 @@
 import asyncio
-import contextvars
 import threading
 from unittest.mock import AsyncMock
 
-from django.db import DEFAULT_DB_ALIAS
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.utils.connection import ConnectionDoesNotExist
 
-from django_async_backend.db import async_connections
-from django_async_backend.test import AsyncioTransactionTestCase
 from django_async_backend.utils.connection import BaseAsyncConnectionHandler
 
 default_settings = {
@@ -247,79 +243,4 @@ class BaseAsyncConnectionHandlerTest(SimpleTestCase):
         self.assertNotEqual(
             origin_connections_map["second"],
             separate_connections_map["second"],
-        )
-
-
-async def _count_pg_backends():
-    """Count other connections to this database in pg_stat_activity."""
-    async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
-        res = await c.execute(
-            "SELECT count(*) FROM pg_stat_activity "
-            "WHERE datname = current_database() "
-            "AND pid != pg_backend_pid()"
-        )
-        row = await res.fetchone()
-        return row[0]
-
-
-class AsyncConnectionCleanupTests(AsyncioTransactionTestCase):
-    """
-    In ASGI, each request runs in its own asyncio task with a fresh
-    ContextVar context. Unlike sync Django (which uses the
-    request_finished signal), there is no built-in mechanism to close
-    async connections when a request ends. Without explicit cleanup,
-    every request leaks a connection that is never returned to the pool.
-    """
-
-    async def test_connections_leak_without_cleanup(self):
-        """Requests without close_all() leak connections."""
-        baseline = await _count_pg_backends()
-
-        n_requests = 20
-        for _ in range(n_requests):
-
-            async def fake_request():
-                async with await async_connections[
-                    DEFAULT_DB_ALIAS
-                ].cursor() as c:
-                    await c.execute("SELECT 1")
-
-            await asyncio.create_task(
-                fake_request(), context=contextvars.Context()
-            )
-
-        after = await _count_pg_backends()
-        leaked = after - baseline
-        self.assertGreaterEqual(
-            leaked,
-            n_requests // 2,
-            f"Expected leaked connections without cleanup, "
-            f"got {leaked}.",
-        )
-
-    async def test_connections_returned_with_cleanup(self):
-        """Requests with close_all() return connections to the pool."""
-        baseline = await _count_pg_backends()
-
-        n_requests = 20
-        for _ in range(n_requests):
-
-            async def fake_request():
-                async with await async_connections[
-                    DEFAULT_DB_ALIAS
-                ].cursor() as c:
-                    await c.execute("SELECT 1")
-                await async_connections.close_all()
-
-            await asyncio.create_task(
-                fake_request(), context=contextvars.Context()
-            )
-
-        after = await _count_pg_backends()
-        leaked = after - baseline
-        self.assertLessEqual(
-            leaked,
-            2,
-            f"Expected ~0 leaked connections with cleanup, "
-            f"got {leaked}.",
         )

--- a/tests/utils/test_connection.py
+++ b/tests/utils/test_connection.py
@@ -1,11 +1,15 @@
 import asyncio
+import contextvars
 import threading
 from unittest.mock import AsyncMock
 
+from django.db import DEFAULT_DB_ALIAS
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.utils.connection import ConnectionDoesNotExist
 
+from django_async_backend.db import async_connections
+from django_async_backend.test import AsyncioTransactionTestCase
 from django_async_backend.utils.connection import BaseAsyncConnectionHandler
 
 default_settings = {
@@ -243,4 +247,79 @@ class BaseAsyncConnectionHandlerTest(SimpleTestCase):
         self.assertNotEqual(
             origin_connections_map["second"],
             separate_connections_map["second"],
+        )
+
+
+async def _count_pg_backends():
+    """Count other connections to this database in pg_stat_activity."""
+    async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+        res = await c.execute(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE datname = current_database() "
+            "AND pid != pg_backend_pid()"
+        )
+        row = await res.fetchone()
+        return row[0]
+
+
+class AsyncConnectionCleanupTests(AsyncioTransactionTestCase):
+    """
+    In ASGI, each request runs in its own asyncio task with a fresh
+    ContextVar context. Unlike sync Django (which uses the
+    request_finished signal), there is no built-in mechanism to close
+    async connections when a request ends. Without explicit cleanup,
+    every request leaks a connection that is never returned to the pool.
+    """
+
+    async def test_connections_leak_without_cleanup(self):
+        """Requests without close_all() leak connections."""
+        baseline = await _count_pg_backends()
+
+        n_requests = 20
+        for _ in range(n_requests):
+
+            async def fake_request():
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as c:
+                    await c.execute("SELECT 1")
+
+            await asyncio.create_task(
+                fake_request(), context=contextvars.Context()
+            )
+
+        after = await _count_pg_backends()
+        leaked = after - baseline
+        self.assertGreaterEqual(
+            leaked,
+            n_requests // 2,
+            f"Expected leaked connections without cleanup, "
+            f"got {leaked}.",
+        )
+
+    async def test_connections_returned_with_cleanup(self):
+        """Requests with close_all() return connections to the pool."""
+        baseline = await _count_pg_backends()
+
+        n_requests = 20
+        for _ in range(n_requests):
+
+            async def fake_request():
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as c:
+                    await c.execute("SELECT 1")
+                await async_connections.close_all()
+
+            await asyncio.create_task(
+                fake_request(), context=contextvars.Context()
+            )
+
+        after = await _count_pg_backends()
+        leaked = after - baseline
+        self.assertLessEqual(
+            leaked,
+            2,
+            f"Expected ~0 leaked connections with cleanup, "
+            f"got {leaked}.",
         )


### PR DESCRIPTION
Fixes https://github.com/Arfey/django-async-backend/issues/14

Django's request_finished signal closes sync connections after each request, but async_connections has no equivalent cleanup. In ASGI, each request runs in its own ContextVar context, opens a connection, and never returns it to the pool. Under load this exhausts the pool.

The middleware calls close_all() after each response, returning connections to the pool. Sync requests pass through unchanged since Django already handles sync connection cleanup.

    MIDDLEWARE = [
        "django_async_backend.middleware.close_async_connections",
        ...
    ]

Tests use pg_stat_activity to verify connections leak without cleanup and are properly returned with it.

## Summary by Sourcery

Introduce middleware to close async database connections after each ASGI request and add tests verifying connection pool cleanup behavior.

New Features:
- Add close_async_connections middleware to ensure async database connections are closed after each request in ASGI deployments.

Bug Fixes:
- Prevent async database connection leaks by calling async_connections.close_all() after handling async requests.

Documentation:
- Document how to enable the close_async_connections middleware in Django settings for ASGI apps.

Tests:
- Add PostgreSQL-backed async tests that confirm connections leak without cleanup and are properly returned to the pool when the middleware runs.