### PR TITLE
Add tests for concurrent async_atomic() transaction corruption

### DIFF
--- a/django_async_backend/db/backends/base/base.py
+++ b/django_async_backend/db/backends/base/base.py
@@ -1,4 +1,5 @@
 import _thread
+import asyncio
 import copy
 import datetime
 import logging
@@ -482,8 +483,8 @@ class BaseAsyncDatabaseWrapper:
         explicit BEGIN with SQLite. This option will be ignored for other
         backends.
         """
-        self.validate_no_atomic_block()
         self.validate_task_sharing()
+        self.validate_no_atomic_block()
         await self.close_if_health_check_failed()
         await self.ensure_connection()
 
@@ -633,6 +634,9 @@ class BaseAsyncDatabaseWrapper:
             )
 
     # ##### Task safety handling #####
+    #
+    # Unlike thread sharing, task sharing needs no lock: asyncio is
+    # single-threaded per event loop and refcount mutations never yield.
 
     @property
     def allow_task_sharing(self):
@@ -659,9 +663,11 @@ class BaseAsyncDatabaseWrapper:
         can start/commit/rollback a transaction or toggle session state
         while another task's queries are interleaving on the same protocol
         stream, causing silent data loss or state corruption.
-        """
-        import asyncio
 
+        When _task is None the wrapper was constructed outside of
+        ``create_connection`` (e.g. ``wrapper.copy()`` in tests); such
+        wrappers have no task ownership and skip the guard.
+        """
         if self._task is None or self.allow_task_sharing:
             return
         try:
@@ -670,11 +676,13 @@ class BaseAsyncDatabaseWrapper:
             current = None
         if self._task is current:
             return
+        owner_name = self._task.get_name() if self._task else "<none>"
+        current_name = current.get_name() if current else "<none>"
         raise DatabaseError(
             "AsyncDatabaseWrapper objects created in one asyncio task can "
             "only be used in that same task. The object with alias '%s' "
-            "was created in task %r and this is task %r."
-            % (self.alias, self._task, current)
+            "was created in task %s and this is task %s."
+            % (self.alias, owner_name, current_name)
         )
 
     # ##### Miscellaneous #####

--- a/django_async_backend/db/backends/base/base.py
+++ b/django_async_backend/db/backends/base/base.py
@@ -81,6 +81,11 @@ class BaseAsyncDatabaseWrapper:
         self.savepoint_ids = []
         # Stack of active 'atomic' blocks.
         self.atomic_blocks = []
+        # asyncio task that owns this connection. Set by the connection
+        # handler at creation time and validated on every operation so
+        # two tasks can't share one connection's transaction/session state.
+        self._task = None
+        self._task_sharing_count = 0
         # Tracks if the outermost 'atomic' block should commit on exit,
         # ie. if autocommit was active on entry.
         self.commit_on_exit = True
@@ -289,6 +294,7 @@ class BaseAsyncDatabaseWrapper:
         Validate the connection is usable and perform database cursor wrapping.
         """
         self.validate_thread_sharing()
+        self.validate_task_sharing()
         if self.queries_logged:
             wrapped_cursor = self.make_debug_cursor(cursor)
         else:
@@ -328,6 +334,7 @@ class BaseAsyncDatabaseWrapper:
     async def commit(self):
         """Commit a transaction and reset the dirty flag."""
         self.validate_thread_sharing()
+        self.validate_task_sharing()
         self.validate_no_atomic_block()
         await self._commit()
         # A successful commit means that the database connection works.
@@ -337,6 +344,7 @@ class BaseAsyncDatabaseWrapper:
     async def rollback(self):
         """Roll back a transaction and reset the dirty flag."""
         self.validate_thread_sharing()
+        self.validate_task_sharing()
         self.validate_no_atomic_block()
         await self._rollback()
         # A successful rollback means that the database connection works.
@@ -347,6 +355,7 @@ class BaseAsyncDatabaseWrapper:
     async def close(self):
         """Close the connection to the database."""
         self.validate_thread_sharing()
+        self.validate_task_sharing()
         self.run_on_commit = []
 
         # Don't call validate_no_atomic_block() to avoid making it difficult
@@ -401,6 +410,7 @@ class BaseAsyncDatabaseWrapper:
         sid = "s%s_x%d" % (tid, self.savepoint_state)
 
         self.validate_thread_sharing()
+        self.validate_task_sharing()
         await self._savepoint(sid)
 
         return sid
@@ -413,6 +423,7 @@ class BaseAsyncDatabaseWrapper:
             return
 
         self.validate_thread_sharing()
+        self.validate_task_sharing()
         await self._savepoint_rollback(sid)
 
         # Remove any callbacks registered while this savepoint was active.
@@ -430,6 +441,7 @@ class BaseAsyncDatabaseWrapper:
             return
 
         self.validate_thread_sharing()
+        self.validate_task_sharing()
         await self._savepoint_commit(sid)
 
     def clean_savepoints(self):
@@ -471,6 +483,7 @@ class BaseAsyncDatabaseWrapper:
         backends.
         """
         self.validate_no_atomic_block()
+        self.validate_task_sharing()
         await self.close_if_health_check_failed()
         await self.ensure_connection()
 
@@ -618,6 +631,51 @@ class BaseAsyncDatabaseWrapper:
                 "thread id %s."
                 % (self.alias, self._thread_ident, _thread.get_ident())
             )
+
+    # ##### Task safety handling #####
+
+    @property
+    def allow_task_sharing(self):
+        return self._task_sharing_count > 0
+
+    def inc_task_sharing(self):
+        self._task_sharing_count += 1
+
+    def dec_task_sharing(self):
+        if self._task_sharing_count <= 0:
+            raise RuntimeError(
+                "Cannot decrement the task sharing count below zero."
+            )
+        self._task_sharing_count -= 1
+
+    def validate_task_sharing(self):
+        """
+        Validate that the connection isn't accessed by an asyncio task other
+        than the one that originally created it, unless the connection was
+        explicitly authorized to be shared between tasks via
+        `inc_task_sharing()`. Raise DatabaseError if the validation fails.
+
+        Sharing a psycopg async connection across tasks is unsafe: one task
+        can start/commit/rollback a transaction or toggle session state
+        while another task's queries are interleaving on the same protocol
+        stream, causing silent data loss or state corruption.
+        """
+        import asyncio
+
+        if self._task is None or self.allow_task_sharing:
+            return
+        try:
+            current = asyncio.current_task()
+        except RuntimeError:
+            current = None
+        if self._task is current:
+            return
+        raise DatabaseError(
+            "AsyncDatabaseWrapper objects created in one asyncio task can "
+            "only be used in that same task. The object with alias '%s' "
+            "was created in task %r and this is task %r."
+            % (self.alias, self._task, current)
+        )
 
     # ##### Miscellaneous #####
 

--- a/django_async_backend/db/transaction.py
+++ b/django_async_backend/db/transaction.py
@@ -92,7 +92,7 @@ class AsyncAtomic(AsyncContextDecorator):
             )
 
         # Reject cross-task nesting (same-task savepoints are fine).
-        if connection.in_atomic_block and not self._from_testcase:
+        if connection.in_atomic_block:
             if connection._task_connection_owner != id(asyncio.current_task()):
                 raise RuntimeError(
                     "Using a transaction in a nested task is forbidden. "

--- a/django_async_backend/db/transaction.py
+++ b/django_async_backend/db/transaction.py
@@ -1,4 +1,3 @@
-import asyncio
 from contextlib import (
     AsyncContextDecorator,
     asynccontextmanager,
@@ -91,26 +90,8 @@ class AsyncAtomic(AsyncContextDecorator):
                 "atomic block."
             )
 
-        # Reject cross-task nesting (same-task savepoints are fine).
-        # Outermost blocks marked _from_testcase deliberately span tasks
-        # (IsolatedAsyncioTestCase runs setUp and tests in separate tasks).
-        if (
-            connection.in_atomic_block
-            and not (
-                connection.atomic_blocks
-                and connection.atomic_blocks[0]._from_testcase
-            )
-            and connection._task_connection_owner is not asyncio.current_task()
-        ):
-            raise RuntimeError(
-                "Using a transaction in a nested task is forbidden. "
-                "Use a higher-level transaction that spans all "
-                "nested tasks, or create a new connection for the "
-                "task via _independent_connection."
-            )
         if not connection.in_atomic_block:
             # Reset state when entering an outermost atomic block.
-            connection._task_connection_owner = asyncio.current_task()
             connection.commit_on_exit = True
             connection.needs_rollback = False
             if not await connection.get_autocommit():

--- a/django_async_backend/db/transaction.py
+++ b/django_async_backend/db/transaction.py
@@ -92,17 +92,25 @@ class AsyncAtomic(AsyncContextDecorator):
             )
 
         # Reject cross-task nesting (same-task savepoints are fine).
-        if connection.in_atomic_block:
-            if connection._task_connection_owner != id(asyncio.current_task()):
-                raise RuntimeError(
-                    "Using a transaction in a nested task is forbidden. "
-                    "Use a higher-level transaction that spans all "
-                    "nested tasks, or create a new connection for the "
-                    "task via _independent_connection."
-                )
+        # Outermost blocks marked _from_testcase deliberately span tasks
+        # (IsolatedAsyncioTestCase runs setUp and tests in separate tasks).
+        if (
+            connection.in_atomic_block
+            and not (
+                connection.atomic_blocks
+                and connection.atomic_blocks[0]._from_testcase
+            )
+            and connection._task_connection_owner is not asyncio.current_task()
+        ):
+            raise RuntimeError(
+                "Using a transaction in a nested task is forbidden. "
+                "Use a higher-level transaction that spans all "
+                "nested tasks, or create a new connection for the "
+                "task via _independent_connection."
+            )
         if not connection.in_atomic_block:
             # Reset state when entering an outermost atomic block.
-            connection._task_connection_owner = id(asyncio.current_task())
+            connection._task_connection_owner = asyncio.current_task()
             connection.commit_on_exit = True
             connection.needs_rollback = False
             if not await connection.get_autocommit():

--- a/django_async_backend/db/transaction.py
+++ b/django_async_backend/db/transaction.py
@@ -70,7 +70,6 @@ class AsyncAtomic(AsyncContextDecorator):
         self.using = using
         self.savepoint = savepoint
         self.durable = durable
-        self._from_testcase = False
 
     async def get_connection(self, using):
         if using is None:
@@ -80,11 +79,7 @@ class AsyncAtomic(AsyncContextDecorator):
     async def __aenter__(self):
         connection = await self.get_connection(self.using)
 
-        if (
-            self.durable
-            and connection.atomic_blocks
-            and not connection.atomic_blocks[-1]._from_testcase
-        ):
+        if self.durable and connection.atomic_blocks:
             raise RuntimeError(
                 "A durable atomic block cannot be nested within another "
                 "atomic block."

--- a/django_async_backend/db/transaction.py
+++ b/django_async_backend/db/transaction.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import (
     AsyncContextDecorator,
     asynccontextmanager,
@@ -89,8 +90,19 @@ class AsyncAtomic(AsyncContextDecorator):
                 "A durable atomic block cannot be nested within another "
                 "atomic block."
             )
+
+        # Reject cross-task nesting (same-task savepoints are fine).
+        if connection.in_atomic_block and not self._from_testcase:
+            if connection._task_connection_owner != id(asyncio.current_task()):
+                raise RuntimeError(
+                    "Using a transaction in a nested task is forbidden. "
+                    "Use a higher-level transaction that spans all "
+                    "nested tasks, or create a new connection for the "
+                    "task via _independent_connection."
+                )
         if not connection.in_atomic_block:
             # Reset state when entering an outermost atomic block.
+            connection._task_connection_owner = id(asyncio.current_task())
             connection.commit_on_exit = True
             connection.needs_rollback = False
             if not await connection.get_autocommit():

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -87,11 +87,14 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
             )
 
         wrapper = backend.AsyncDatabaseWrapper(db, alias)
-        task = asyncio.current_task()
+        try:
+            task = asyncio.current_task()
+        except RuntimeError:
+            task = None
         if task is None:
             raise RuntimeError(
                 "Cannot create an async connection without a running "
                 "event loop."
             )
-        wrapper._task_connection_owner = id(task)
+        wrapper._task_connection_owner = task
         return wrapper

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -91,5 +91,10 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
             task = asyncio.current_task()
         except RuntimeError:
             task = None
-        wrapper._task_connection_owner = id(task) if task else None
+        if task is None:
+            raise RuntimeError(
+                "Cannot create an async connection without a running "
+                "event loop."
+            )
+        wrapper._task_connection_owner = id(task)
         return wrapper

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -86,7 +86,6 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
                 f"The async connection '{alias}' doesn't exist."
             )
 
-        wrapper = backend.AsyncDatabaseWrapper(db, alias)
         try:
             task = asyncio.current_task()
         except RuntimeError:
@@ -96,5 +95,6 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
                 "Cannot create an async connection without a running "
                 "event loop."
             )
-        wrapper._task_connection_owner = task
+        wrapper = backend.AsyncDatabaseWrapper(db, alias)
+        wrapper._task = task
         return wrapper

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from asgiref.sync import iscoroutinefunction
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS
@@ -84,4 +86,10 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
                 f"The async connection '{alias}' doesn't exist."
             )
 
-        return backend.AsyncDatabaseWrapper(db, alias)
+        wrapper = backend.AsyncDatabaseWrapper(db, alias)
+        try:
+            task = asyncio.current_task()
+        except RuntimeError:
+            task = None
+        wrapper._task_connection_owner = id(task) if task else None
+        return wrapper

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -87,10 +87,7 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
             )
 
         wrapper = backend.AsyncDatabaseWrapper(db, alias)
-        try:
-            task = asyncio.current_task()
-        except RuntimeError:
-            task = None
+        task = asyncio.current_task()
         if task is None:
             raise RuntimeError(
                 "Cannot create an async connection without a running "

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -33,7 +33,6 @@ def close_async_connections(get_response):
                 await asyncio.shield(async_connections.close_all())
             finally:
                 for conn in conns:
-                    if conn._task_sharing_count > 0:
-                        conn.dec_task_sharing()
+                    conn.dec_task_sharing()
 
     return middleware

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -23,6 +23,17 @@ def close_async_connections(get_response):
         try:
             return await get_response(request)
         finally:
-            await asyncio.shield(async_connections.close_all())
+            # asyncio.shield runs close_all in a sub-task, which would
+            # fail validate_task_sharing. Explicitly allow the shielded
+            # close to touch connections owned by the request task.
+            conns = async_connections.all(initialized_only=True)
+            for conn in conns:
+                conn.inc_task_sharing()
+            try:
+                await asyncio.shield(async_connections.close_all())
+            finally:
+                for conn in conns:
+                    if conn._task_sharing_count > 0:
+                        conn.dec_task_sharing()
 
     return middleware

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -23,6 +23,7 @@ class AsyncioTestCase(AsyncioTransactionTestCase):
             connection = async_connections[name]
             self.connections[name] = connection
             self.atomic_cms[name] = async_atomic(name)
+            self.atomic_cms[name]._from_testcase = True
             self.atomics[name] = await self.atomic_cms[name].__aenter__()
 
     async def _close_transaction(self):

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -9,7 +9,30 @@ from django_async_backend.db.transaction import async_atomic
 
 class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
     # todo: fix problem with creating models
-    pass
+
+    async def _enter_task_sharing(self):
+        # IsolatedAsyncioTestCase runs setUp, test, and tearDown in
+        # different asyncio tasks but tests expect to share a single
+        # connection across them. Mark every configured connection as
+        # task-shared for the duration of the test. Register dec as an
+        # async cleanup so it runs after user cleanups (LIFO ordering
+        # means the first-registered cleanup is the last to execute).
+        self._shared_connections = []
+        for name in async_connections.settings.keys():
+            conn = async_connections[name]
+            conn.inc_task_sharing()
+            self._shared_connections.append(conn)
+        self.addAsyncCleanup(self._exit_task_sharing)
+
+    async def _exit_task_sharing(self):
+        for conn in self._shared_connections:
+            conn.dec_task_sharing()
+
+    def _callSetUp(self):
+        self._asyncioRunner.get_loop()
+        self._asyncioTestContext.run(self.setUp)
+        self._callAsync(self._enter_task_sharing)
+        self._callAsync(self.asyncSetUp)
 
 
 class AsyncioTestCase(AsyncioTransactionTestCase):
@@ -23,7 +46,6 @@ class AsyncioTestCase(AsyncioTransactionTestCase):
             connection = async_connections[name]
             self.connections[name] = connection
             self.atomic_cms[name] = async_atomic(name)
-            self.atomic_cms[name]._from_testcase = True
             self.atomics[name] = await self.atomic_cms[name].__aenter__()
 
     async def _close_transaction(self):
@@ -39,6 +61,7 @@ class AsyncioTestCase(AsyncioTransactionTestCase):
         # correct loop instance.
         self._asyncioRunner.get_loop()
         self._asyncioTestContext.run(self.setUp)
+        self._callAsync(self._enter_task_sharing)
         self._callAsync(self._init_transaction)
         self._callAsync(self.asyncSetUp)
 

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -10,7 +10,13 @@ from django_async_backend.db.transaction import async_atomic
 class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
     # todo: fix problem with creating models
 
-    async def _enter_task_sharing(self):
+    async def _async_pre_setup(self):
+        """Hook run between setUp and asyncSetUp.
+
+        Subclasses can override to add their own pre-setup, but must call
+        super() first so connection task-sharing is enabled before their
+        setup touches any connection.
+        """
         # IsolatedAsyncioTestCase runs setUp, test, and tearDown in
         # different asyncio tasks but tests expect to share a single
         # connection across them. Mark every configured connection as
@@ -29,18 +35,19 @@ class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
             conn.dec_task_sharing()
 
     def _callSetUp(self):
-        # Replicates IsolatedAsyncioTestCase._callSetUp (CPython 3.13) and
-        # injects _enter_task_sharing before asyncSetUp. We can't super()
-        # because we need to run code between setUp and asyncSetUp.
+        # Mirrors IsolatedAsyncioTestCase._callSetUp and inserts
+        # _async_pre_setup between setUp and asyncSetUp. We can't super()
+        # because we need to run code between those two hooks.
         self._asyncioRunner.get_loop()
         self._asyncioTestContext.run(self.setUp)
-        self._callAsync(self._enter_task_sharing)
+        self._callAsync(self._async_pre_setup)
         self._callAsync(self.asyncSetUp)
 
 
 class AsyncioTestCase(AsyncioTransactionTestCase):
 
-    async def _init_transaction(self):
+    async def _async_pre_setup(self):
+        await super()._async_pre_setup()
         self.connections = {}
         self.atomic_cms = {}
         self.atomics = {}
@@ -57,16 +64,6 @@ class AsyncioTestCase(AsyncioTransactionTestCase):
             connection.set_rollback(True)
             await self.atomic_cms[name].__aexit__(None, None, None)
             await connection.close()
-
-    def _callSetUp(self):
-        # Force loop to be initialized and set as the current loop
-        # so that setUp functions can use get_event_loop() and get the
-        # correct loop instance.
-        self._asyncioRunner.get_loop()
-        self._asyncioTestContext.run(self.setUp)
-        self._callAsync(self._enter_task_sharing)
-        self._callAsync(self._init_transaction)
-        self._callAsync(self.asyncSetUp)
 
     def _callTearDown(self):
         self._callAsync(self.asyncTearDown)

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -29,6 +29,9 @@ class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
             conn.dec_task_sharing()
 
     def _callSetUp(self):
+        # Replicates IsolatedAsyncioTestCase._callSetUp (CPython 3.13) and
+        # injects _enter_task_sharing before asyncSetUp. We can't super()
+        # because we need to run code between setUp and asyncSetUp.
         self._asyncioRunner.get_loop()
         self._asyncioTestContext.run(self.setUp)
         self._callAsync(self._enter_task_sharing)

--- a/django_async_backend/utils/connection.py
+++ b/django_async_backend/utils/connection.py
@@ -34,5 +34,8 @@ class BaseAsyncConnectionHandler(BaseConnectionHandler):
             new_connections = self.all()
             for conn in connections:
                 self[conn.alias] = conn
+            # Sequential close, not asyncio.gather: each independent
+            # conn is task-owned by the current task, and gather's
+            # sub-tasks would fail validate_task_sharing.
             for conn in new_connections:
                 await conn.close()

--- a/django_async_backend/utils/connection.py
+++ b/django_async_backend/utils/connection.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 
 from django.utils.connection import BaseConnectionHandler
@@ -6,19 +7,9 @@ from django.utils.connection import BaseConnectionHandler
 class BaseAsyncConnectionHandler(BaseConnectionHandler):
 
     async def close_all(self):
-        # close_all() is called from middleware cleanup paths that may
-        # shield into a new task (asyncio.shield wraps in a sub-task),
-        # so grant task sharing while closing — the alternative is
-        # forcing every caller to inc/dec around the call.
-        conns = self.all(initialized_only=True)
-        for conn in conns:
-            conn.inc_task_sharing()
-        try:
-            for conn in conns:
-                await conn.close()
-        finally:
-            for conn in conns:
-                conn.dec_task_sharing()
+        await asyncio.gather(
+            *[conn.close() for conn in self.all(initialized_only=True)]
+        )
 
     @asynccontextmanager
     async def _independent_connection(self):

--- a/django_async_backend/utils/connection.py
+++ b/django_async_backend/utils/connection.py
@@ -1,4 +1,3 @@
-import asyncio
 from contextlib import asynccontextmanager
 
 from django.utils.connection import BaseConnectionHandler
@@ -7,9 +6,19 @@ from django.utils.connection import BaseConnectionHandler
 class BaseAsyncConnectionHandler(BaseConnectionHandler):
 
     async def close_all(self):
-        await asyncio.gather(
-            *[conn.close() for conn in self.all(initialized_only=True)]
-        )
+        # close_all() is called from middleware cleanup paths that may
+        # shield into a new task (asyncio.shield wraps in a sub-task),
+        # so grant task sharing while closing — the alternative is
+        # forcing every caller to inc/dec around the call.
+        conns = self.all(initialized_only=True)
+        for conn in conns:
+            conn.inc_task_sharing()
+        try:
+            for conn in conns:
+                await conn.close()
+        finally:
+            for conn in conns:
+                conn.dec_task_sharing()
 
     @asynccontextmanager
     async def _independent_connection(self):
@@ -31,9 +40,8 @@ class BaseAsyncConnectionHandler(BaseConnectionHandler):
                 self[conn.alias] = self.create_connection(conn.alias)
             yield
         finally:
-            close_task = asyncio.gather(*[conn.close() for conn in self.all()])
-
+            new_connections = self.all()
             for conn in connections:
                 self[conn.alias] = conn
-
-            await close_task
+            for conn in new_connections:
+                await conn.close()

--- a/tests/db/backends/postgresql/test_base.py
+++ b/tests/db/backends/postgresql/test_base.py
@@ -8,7 +8,7 @@ from django_async_backend.db.backends.postgresql.base import DatabaseWrapper
 
 
 class TestDatabaseWrapper(TestCase):
-    def test_warning_with_pool(self):
+    async def test_warning_with_pool(self):
         connection = async_connections[DEFAULT_DB_ALIAS]
 
         settings_dict = connection.settings_dict.copy()
@@ -17,7 +17,7 @@ class TestDatabaseWrapper(TestCase):
         with self.assertWarns(RuntimeWarning):
             DatabaseWrapper(settings_dict).get_connection_params()
 
-    def test_no_warning_without_pool(self):
+    async def test_no_warning_without_pool(self):
         connection = async_connections[DEFAULT_DB_ALIAS]
 
         settings_dict = connection.settings_dict.copy()
@@ -35,7 +35,7 @@ class TestDatabaseWrapper(TestCase):
             "RuntimeWarning was raised even though pool option is not enabled.",
         )
 
-    def test_no_warning_when_pool_warning_disabled(self):
+    async def test_no_warning_when_pool_warning_disabled(self):
         connection = async_connections[DEFAULT_DB_ALIAS]
 
         settings_dict = connection.settings_dict.copy()

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -352,7 +352,6 @@ class AsyncAtomicInsideTransactionTests(AsyncAtomicTests):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         self.atomic = async_atomic()
-        self.atomic._from_testcase = True
         await self.atomic.__aenter__()
 
     async def asyncTearDown(self):
@@ -596,15 +595,15 @@ class IndependentConnectionTransaction(AsyncioTransactionTestCase):
 
 class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
     """
-    Child tasks created via gather/create_task inherit the parent's
-    connection via ContextVar. If a child opens its own async_atomic(),
-    it would create overlapping transactions on the shared connection,
-    corrupting state. A guard in __aenter__ raises RuntimeError with
-    a clear message instead of allowing silent corruption.
+    Child tasks that inherit a parent's connection via ContextVar can
+    corrupt transaction state or silently lose writes by sharing the
+    same psycopg async connection. validate_task_sharing on every
+    cursor/commit/rollback rejects the sharing with DatabaseError
+    (unless explicitly allowed via inc_task_sharing).
 
     Correct patterns:
-      - Wrap all tasks in a single parent async_atomic()
       - Use _independent_connection() per task
+      - inc_task_sharing() around code that deliberately shares
     """
 
     async def asyncSetUp(self):
@@ -613,43 +612,53 @@ class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
     async def asyncTearDown(self):
         await drop_table()
 
-    async def test_child_task_atomic_raises(self):
-        """async_atomic() in a child task raises RuntimeError."""
-
-        async def writer():
-            async with async_atomic():
+    async def test_child_task_cursor_raises(self):
+        """A child task using the parent's connection raises."""
+        # asyncSetUp's inc_task_sharing is still active across the whole
+        # test, so temporarily dec to exercise the guard.
+        conn = async_connections[DEFAULT_DB_ALIAS]
+        conn.dec_task_sharing()
+        try:
+            async def writer():
                 await create_instance("should_fail")
 
-        async with async_atomic():
-            with self.assertRaisesRegex(
-                RuntimeError, "nested task"
-            ):
+            with self.assertRaisesRegex(DatabaseError, "same task"):
                 await asyncio.create_task(writer())
+        finally:
+            conn.inc_task_sharing()
 
-    async def test_concurrent_gather_atomic_raises(self):
-        """gather() where each task opens async_atomic() raises.
+    async def test_cross_task_transaction_inheritance_raises(self):
+        """Cross-task connection use with one task in atomic raises.
 
-        This is the original issue #11 pattern — no parent atomic,
-        each child independently opens async_atomic(). The first
-        child stamps the connection, subsequent children see the
-        mismatch.
+        Reproduces the bug pattern: main task issues raw SQL while an
+        audit task has opened an async_atomic. Without per-query
+        validation this is silent data loss; with validation the
+        interloping cursor use raises DatabaseError.
         """
-        barrier = asyncio.Barrier(10)
+        conn = async_connections[DEFAULT_DB_ALIAS]
+        conn.dec_task_sharing()
+        try:
+            async def main_task():
+                await create_instance("main")
 
-        async def writer(task_id):
-            await barrier.wait()
-            async with async_atomic():
-                await create_instance(f"t{task_id}")
-                await asyncio.sleep(0)
+            async def audit_task():
+                try:
+                    async with async_atomic():
+                        await create_instance("audit")
+                        raise RuntimeError("rollback")
+                except RuntimeError:
+                    pass
 
-        results = await asyncio.gather(
-            *(writer(i) for i in range(10)), return_exceptions=True
-        )
-        errors = [r for r in results if isinstance(r, RuntimeError)]
-        self.assertTrue(
-            len(errors) > 0,
-            "Expected RuntimeError from concurrent async_atomic()",
-        )
+            results = await asyncio.gather(
+                main_task(), audit_task(), return_exceptions=True
+            )
+            errors = [r for r in results if isinstance(r, DatabaseError)]
+            self.assertTrue(
+                len(errors) > 0,
+                "Expected DatabaseError from cross-task connection use",
+            )
+        finally:
+            conn.inc_task_sharing()
 
     async def test_nested_savepoint_same_task_works(self):
         """Nested async_atomic() in the same task is a savepoint."""

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -725,11 +725,11 @@ class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
         self.assertEqual(await get_all(), [])
 
     async def test_inc_task_sharing_allows_cross_task_use(self):
-        """inc_task_sharing is the documented escape hatch."""
-        conn = async_connections[DEFAULT_DB_ALIAS]
-        # Test framework already has it inc'd; verify cross-task use
-        # actually works rather than relying on implicit state.
+        """inc_task_sharing is the documented escape hatch.
 
+        Test framework already has it inc'd; verify cross-task use
+        actually works rather than relying on implicit state.
+        """
         async def writer():
             await create_instance("shared")
 

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import sys
 
 from django.db import (
@@ -612,20 +613,31 @@ class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
     async def asyncTearDown(self):
         await drop_table()
 
-    async def test_child_task_cursor_raises(self):
-        """A child task using the parent's connection raises."""
-        # asyncSetUp's inc_task_sharing is still active across the whole
-        # test, so temporarily dec to exercise the guard.
-        conn = async_connections[DEFAULT_DB_ALIAS]
+    @contextlib.asynccontextmanager
+    async def _strict_task_sharing(self, conn):
+        """Temporarily disable task sharing the test framework enabled.
+
+        AsyncioTransactionTestCase inc_task_sharing for the whole test
+        lifecycle so setUp and test methods (which run in different
+        tasks) can share one connection. To exercise validate_task_sharing
+        itself we need to turn that off for the scope of the assertion.
+        """
         conn.dec_task_sharing()
         try:
+            yield
+        finally:
+            conn.inc_task_sharing()
+
+    async def test_child_task_cursor_raises(self):
+        """A child task using the parent's connection raises."""
+        conn = async_connections[DEFAULT_DB_ALIAS]
+        async with self._strict_task_sharing(conn):
             async def writer():
                 await create_instance("should_fail")
 
             with self.assertRaisesRegex(DatabaseError, "same task"):
                 await asyncio.create_task(writer())
-        finally:
-            conn.inc_task_sharing()
+        self.assertEqual(await get_all(), [])
 
     async def test_cross_task_transaction_inheritance_raises(self):
         """Cross-task connection use with one task in atomic raises.
@@ -633,11 +645,11 @@ class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
         Reproduces the bug pattern: main task issues raw SQL while an
         audit task has opened an async_atomic. Without per-query
         validation this is silent data loss; with validation the
-        interloping cursor use raises DatabaseError.
+        interloping cursor use raises DatabaseError and — crucially —
+        nothing is written to the database.
         """
         conn = async_connections[DEFAULT_DB_ALIAS]
-        conn.dec_task_sharing()
-        try:
+        async with self._strict_task_sharing(conn):
             async def main_task():
                 await create_instance("main")
 
@@ -657,8 +669,38 @@ class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
                 len(errors) > 0,
                 "Expected DatabaseError from cross-task connection use",
             )
-        finally:
-            conn.inc_task_sharing()
+        # The real regression guard: nothing got committed.
+        self.assertEqual(await get_all(), [])
+
+    async def test_cross_task_set_autocommit_raises(self):
+        """Cross-task set_autocommit raises (class C: session state)."""
+        conn = async_connections[DEFAULT_DB_ALIAS]
+        async with self._strict_task_sharing(conn):
+            async def toggle():
+                await conn.set_autocommit(False)
+
+            with self.assertRaisesRegex(DatabaseError, "same task"):
+                await asyncio.create_task(toggle())
+
+    async def test_inc_task_sharing_allows_cross_task_use(self):
+        """inc_task_sharing is the documented escape hatch."""
+        conn = async_connections[DEFAULT_DB_ALIAS]
+        # Test framework already has it inc'd; verify cross-task use
+        # actually works rather than relying on implicit state.
+
+        async def writer():
+            await create_instance("shared")
+
+        await asyncio.create_task(writer())
+        self.assertEqual(await get_all(), ["shared"])
+
+    async def test_dec_task_sharing_below_zero_raises(self):
+        """Refcount cannot be decremented below zero."""
+        conn = async_connections[DEFAULT_DB_ALIAS]
+        async with self._strict_task_sharing(conn):
+            # Sharing count is now 0; another dec should raise.
+            with self.assertRaisesRegex(RuntimeError, "below zero"):
+                conn.dec_task_sharing()
 
     async def test_nested_savepoint_same_task_works(self):
         """Nested async_atomic() in the same task is a savepoint."""

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -352,6 +352,7 @@ class AsyncAtomicInsideTransactionTests(AsyncAtomicTests):
     async def asyncSetUp(self):
         await super().asyncSetUp()
         self.atomic = async_atomic()
+        self.atomic._from_testcase = True
         await self.atomic.__aenter__()
 
     async def asyncTearDown(self):
@@ -633,20 +634,18 @@ class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
         child stamps the connection, subsequent children see the
         mismatch.
         """
-        errors = []
         barrier = asyncio.Barrier(10)
 
         async def writer(task_id):
-            try:
-                await barrier.wait()
-                async with async_atomic():
-                    await create_instance(f"t{task_id}")
-                    await asyncio.sleep(0)
-            except RuntimeError as e:
-                errors.append((task_id, e))
+            await barrier.wait()
+            async with async_atomic():
+                await create_instance(f"t{task_id}")
+                await asyncio.sleep(0)
 
-        await asyncio.gather(*(writer(i) for i in range(10)))
-
+        results = await asyncio.gather(
+            *(writer(i) for i in range(10)), return_exceptions=True
+        )
+        errors = [r for r in results if isinstance(r, RuntimeError)]
         self.assertTrue(
             len(errors) > 0,
             "Expected RuntimeError from concurrent async_atomic()",
@@ -673,38 +672,34 @@ class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
     async def test_parent_atomic_avoids_corruption(self):
         """Single parent async_atomic wrapping gather() works."""
         barrier = asyncio.Barrier(10)
-        errors = []
 
         async def writer(task_id):
-            try:
-                await barrier.wait()
-                await create_instance(f"p{task_id}")
-                await asyncio.sleep(0)
-            except Exception as e:
-                errors.append((task_id, e))
+            await barrier.wait()
+            await create_instance(f"p{task_id}")
+            await asyncio.sleep(0)
 
         async with async_atomic():
-            await asyncio.gather(*(writer(i) for i in range(10)))
+            results = await asyncio.gather(
+                *(writer(i) for i in range(10)), return_exceptions=True
+            )
 
-        self.assertEqual(errors, [])
+        self.assertEqual([r for r in results if isinstance(r, Exception)], [])
         self.assertEqual(len(await get_all()), 10)
 
     async def test_independent_connection_avoids_corruption(self):
         """_independent_connection() per task avoids corruption."""
         barrier = asyncio.Barrier(10)
-        errors = []
 
         async def writer(task_id):
-            try:
-                await barrier.wait()
-                async with async_connections._independent_connection():
-                    async with async_atomic():
-                        await create_instance(f"i{task_id}")
-                        await asyncio.sleep(0)
-            except Exception as e:
-                errors.append((task_id, e))
+            await barrier.wait()
+            async with async_connections._independent_connection():
+                async with async_atomic():
+                    await create_instance(f"i{task_id}")
+                    await asyncio.sleep(0)
 
-        await asyncio.gather(*(writer(i) for i in range(10)))
+        results = await asyncio.gather(
+            *(writer(i) for i in range(10)), return_exceptions=True
+        )
 
-        self.assertEqual(errors, [])
+        self.assertEqual([r for r in results if isinstance(r, Exception)], [])
         self.assertEqual(len(await get_all()), 10)

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 from django.db import (
@@ -590,3 +591,120 @@ class IndependentConnectionTransaction(AsyncioTransactionTestCase):
                         await create_instance(2)
 
                         self.assertEqual(len(await get_all()), 1)
+
+
+class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
+    """
+    Child tasks created via gather/create_task inherit the parent's
+    connection via ContextVar. If a child opens its own async_atomic(),
+    it would create overlapping transactions on the shared connection,
+    corrupting state. A guard in __aenter__ raises RuntimeError with
+    a clear message instead of allowing silent corruption.
+
+    Correct patterns:
+      - Wrap all tasks in a single parent async_atomic()
+      - Use _independent_connection() per task
+    """
+
+    async def asyncSetUp(self):
+        await create_table()
+
+    async def asyncTearDown(self):
+        await drop_table()
+
+    async def test_child_task_atomic_raises(self):
+        """async_atomic() in a child task raises RuntimeError."""
+
+        async def writer():
+            async with async_atomic():
+                await create_instance("should_fail")
+
+        async with async_atomic():
+            with self.assertRaisesRegex(
+                RuntimeError, "nested task"
+            ):
+                await asyncio.create_task(writer())
+
+    async def test_concurrent_gather_atomic_raises(self):
+        """gather() where each task opens async_atomic() raises.
+
+        This is the original issue #11 pattern — no parent atomic,
+        each child independently opens async_atomic(). The first
+        child stamps the connection, subsequent children see the
+        mismatch.
+        """
+        errors = []
+        barrier = asyncio.Barrier(10)
+
+        async def writer(task_id):
+            try:
+                await barrier.wait()
+                async with async_atomic():
+                    await create_instance(f"t{task_id}")
+                    await asyncio.sleep(0)
+            except RuntimeError as e:
+                errors.append((task_id, e))
+
+        await asyncio.gather(*(writer(i) for i in range(10)))
+
+        self.assertTrue(
+            len(errors) > 0,
+            "Expected RuntimeError from concurrent async_atomic()",
+        )
+
+    async def test_nested_savepoint_same_task_works(self):
+        """Nested async_atomic() in the same task is a savepoint."""
+        async with async_atomic():
+            await create_instance("outer")
+            async with async_atomic():
+                await create_instance("inner")
+
+        self.assertEqual(len(await get_all()), 2)
+
+    async def test_sequential_atomic_same_task_works(self):
+        """Sequential async_atomic() calls in the same task work."""
+        async with async_atomic():
+            await create_instance("first")
+        async with async_atomic():
+            await create_instance("second")
+
+        self.assertEqual(len(await get_all()), 2)
+
+    async def test_parent_atomic_avoids_corruption(self):
+        """Single parent async_atomic wrapping gather() works."""
+        barrier = asyncio.Barrier(10)
+        errors = []
+
+        async def writer(task_id):
+            try:
+                await barrier.wait()
+                await create_instance(f"p{task_id}")
+                await asyncio.sleep(0)
+            except Exception as e:
+                errors.append((task_id, e))
+
+        async with async_atomic():
+            await asyncio.gather(*(writer(i) for i in range(10)))
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(await get_all()), 10)
+
+    async def test_independent_connection_avoids_corruption(self):
+        """_independent_connection() per task avoids corruption."""
+        barrier = asyncio.Barrier(10)
+        errors = []
+
+        async def writer(task_id):
+            try:
+                await barrier.wait()
+                async with async_connections._independent_connection():
+                    async with async_atomic():
+                        await create_instance(f"i{task_id}")
+                        await asyncio.sleep(0)
+            except Exception as e:
+                errors.append((task_id, e))
+
+        await asyncio.gather(*(writer(i) for i in range(10)))
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(await get_all()), 10)

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -682,6 +682,48 @@ class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
             with self.assertRaisesRegex(DatabaseError, "same task"):
                 await asyncio.create_task(toggle())
 
+    async def test_cross_task_close_raises(self):
+        """close() is a user-facing API — must fire the guard too."""
+        conn = async_connections[DEFAULT_DB_ALIAS]
+        async with self._strict_task_sharing(conn):
+            async def closer():
+                await conn.close()
+
+            with self.assertRaisesRegex(DatabaseError, "same task"):
+                await asyncio.create_task(closer())
+
+    async def test_fanout_gather_atomic_raises(self):
+        """Fan-out pattern from issue #11: N gather'd tasks each open
+        their own async_atomic on the shared connection.
+
+        Proves validate_task_sharing short-circuits *every* child's
+        atomic entry rather than only the first one in sibling/audit
+        shape. Without strict sharing this would match issue #11's
+        ProgrammingError 'connection in transaction status INTRANS';
+        with strict sharing we expect clean DatabaseError instead.
+        """
+        conn = async_connections[DEFAULT_DB_ALIAS]
+        async with self._strict_task_sharing(conn):
+            barrier = asyncio.Barrier(5)
+
+            async def writer(i):
+                await barrier.wait()
+                async with async_atomic():
+                    await create_instance(f"fanout{i}")
+
+            results = await asyncio.gather(
+                *(writer(i) for i in range(5)), return_exceptions=True
+            )
+            db_errors = [
+                r for r in results if isinstance(r, DatabaseError)
+            ]
+            self.assertEqual(
+                len(db_errors), 5,
+                f"expected 5 DatabaseError, got {results!r}",
+            )
+        # Nothing persisted: the guard short-circuits before BEGIN.
+        self.assertEqual(await get_all(), [])
+
     async def test_inc_task_sharing_allows_cross_task_use(self):
         """inc_task_sharing is the documented escape hatch."""
         conn = async_connections[DEFAULT_DB_ALIAS]


### PR DESCRIPTION
Unit test for https://github.com/Arfey/django-async-backend/issues/11

Concurrent child tasks that share a connection via ContextVar inheritance each opening their own async_atomic() corrupt transaction state - one task sets autocommit=False while another's transaction is already active on the same connection.

## Summary by Sourcery

Add safeguards against cross-task misuse of async_atomic() and validate correct transactional patterns under concurrent async usage.

Bug Fixes:
- Prevent concurrent child tasks from sharing a connection and opening overlapping async_atomic() blocks by raising a clear RuntimeError when a transaction is used from a different task than the connection owner.

Enhancements:
- Track the owning task of each async database connection to distinguish safe same-task nesting from unsafe cross-task transactional usage.

Tests:
- Add async test cases covering error behavior for child tasks and concurrent gathers that open async_atomic(), and success cases for same-task nesting, parent-wrapped transactions, and per-task independent connections.