### PR TITLE
introduce async_atomic tasks restriction

### DIFF
--- a/django_async_backend/db/transaction.py
+++ b/django_async_backend/db/transaction.py
@@ -83,10 +83,10 @@ class AsyncAtomic(AsyncContextDecorator):
 
         if connection._task is not asyncio.current_task():
             raise RuntimeError(
-                "Using a transaction in a nested task is forbidden. "
-                "Use a higher-level transaction that spans all "
-                "nested tasks, or create a new connection for the "
-                "task via _independent_connection."
+                "Transactions cannot be used within nested tasks. "
+                "Consider using a higher-level transaction that "
+                "encompasses all nested tasks, or establish a separate "
+                "connection for the task (e.g., _independent_connection)."
             )
 
         if (

--- a/django_async_backend/db/transaction.py
+++ b/django_async_backend/db/transaction.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import (
     AsyncContextDecorator,
     asynccontextmanager,
@@ -79,6 +80,14 @@ class AsyncAtomic(AsyncContextDecorator):
 
     async def __aenter__(self):
         connection = await self.get_connection(self.using)
+
+        if connection._task is not asyncio.current_task():
+            raise RuntimeError(
+                "Using a transaction in a nested task is forbidden. "
+                "Use a higher-level transaction that spans all "
+                "nested tasks, or create a new connection for the "
+                "task via _independent_connection."
+            )
 
         if (
             self.durable

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from asgiref.sync import iscoroutinefunction
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS
@@ -84,4 +86,16 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
                 f"The async connection '{alias}' doesn't exist."
             )
 
-        return backend.AsyncDatabaseWrapper(db, alias)
+        try:
+            task = asyncio.current_task()
+        except RuntimeError:
+            task = None
+
+        if task is None:
+            raise RuntimeError(
+                "Cannot create an async connection without a running "
+                "event loop."
+            )
+        wrapper = backend.AsyncDatabaseWrapper(db, alias)
+        wrapper._task = task
+        return wrapper

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import IsolatedAsyncioTestCase
 
 from django.core.signals import request_started
@@ -7,9 +8,29 @@ from django_async_backend.db import async_connections
 from django_async_backend.db.transaction import async_atomic
 
 
+def _refresh_connection_task_ownership_decorator(fn):
+    async def inner(*args, **kwargs):
+        task = asyncio.current_task()
+        for name in async_connections.settings.keys():
+            connection = async_connections[name]
+            connection._task = task
+        return await fn(*args, **kwargs)
+
+    return inner
+
+
 class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
     # todo: fix problem with creating models
-    pass
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        for name, method in list(vars(cls).items()):
+            if name.startswith("test") and callable(method):
+                setattr(
+                    cls,
+                    name,
+                    _refresh_connection_task_ownership_decorator(method),
+                )
 
 
 class AsyncioTestCase(AsyncioTransactionTestCase):

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -1,4 +1,5 @@
 import asyncio
+from functools import wraps
 from unittest import IsolatedAsyncioTestCase
 
 from django.core.signals import request_started
@@ -9,6 +10,7 @@ from django_async_backend.db.transaction import async_atomic
 
 
 def _refresh_connection_task_ownership_decorator(fn):
+    @wraps(fn)
     async def inner(*args, **kwargs):
         task = asyncio.current_task()
         for name in async_connections.settings.keys():

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -32,6 +32,28 @@ class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
                     _refresh_connection_task_ownership_decorator(method),
                 )
 
+    def _callSetUp(self):
+        self._asyncioRunner.get_loop()
+        self._asyncioTestContext.run(self.setUp)
+        self._callAsync(
+            _refresh_connection_task_ownership_decorator(self.asyncSetUp)
+        )
+
+    async def _close_connection(self):
+        for name in async_connections.settings.keys():
+            await async_connections[name].close()
+
+    def _callTearDown(self):
+        self._callAsync(
+            _refresh_connection_task_ownership_decorator(self.asyncTearDown)
+        )
+        self._callAsync(
+            _refresh_connection_task_ownership_decorator(
+                self._close_connection
+            )
+        )
+        self._asyncioTestContext.run(self.tearDown)
+
 
 class AsyncioTestCase(AsyncioTransactionTestCase):
 
@@ -60,10 +82,14 @@ class AsyncioTestCase(AsyncioTransactionTestCase):
         self._asyncioRunner.get_loop()
         self._asyncioTestContext.run(self.setUp)
         self._callAsync(self._init_transaction)
-        self._callAsync(self.asyncSetUp)
+        self._callAsync(
+            _refresh_connection_task_ownership_decorator(self.asyncSetUp)
+        )
 
     def _callTearDown(self):
-        self._callAsync(self.asyncTearDown)
+        self._callAsync(
+            _refresh_connection_task_ownership_decorator(self.asyncTearDown)
+        )
         self._callAsync(self._close_transaction)
         self._asyncioTestContext.run(self.tearDown)
 

--- a/tests/db/backends/postgresql/test_async_backend.py
+++ b/tests/db/backends/postgresql/test_async_backend.py
@@ -464,12 +464,10 @@ class Tests(AsyncioTestCase):
         with mock.patch.object(
             Database, "__version__", "4.2.1 (dt dec pq3 ext lo64)"
         ):
-            psycopg_version.cache_clear()
             self.assertEqual(psycopg_version(), (4, 2, 1))
         with mock.patch.object(
             Database, "__version__", "4.2b0.dev1 (dt dec pq3 ext lo64)"
         ):
-            psycopg_version.cache_clear()
             self.assertEqual(psycopg_version(), (4, 2))
 
     @override_settings(DEBUG=True)

--- a/tests/db/backends/postgresql/test_async_backend.py
+++ b/tests/db/backends/postgresql/test_async_backend.py
@@ -464,10 +464,12 @@ class Tests(AsyncioTestCase):
         with mock.patch.object(
             Database, "__version__", "4.2.1 (dt dec pq3 ext lo64)"
         ):
+            psycopg_version.cache_clear()
             self.assertEqual(psycopg_version(), (4, 2, 1))
         with mock.patch.object(
             Database, "__version__", "4.2b0.dev1 (dt dec pq3 ext lo64)"
         ):
+            psycopg_version.cache_clear()
             self.assertEqual(psycopg_version(), (4, 2))
 
     @override_settings(DEBUG=True)
@@ -509,7 +511,7 @@ class Tests(AsyncioTestCase):
         await new_connection.connect()
         settings = new_connection.settings_dict.copy()
 
-        msg = r"PostgreSQL 14 or later is required \(found 13\)."
+        msg = r"or later is required \(found 13\)."
         with self.assertRaisesRegex(NotSupportedError, msg):
             await CustomAsyncDatabaseWrapper(
                 settings

--- a/tests/db/backends/postgresql/test_base.py
+++ b/tests/db/backends/postgresql/test_base.py
@@ -8,7 +8,7 @@ from django_async_backend.db.backends.postgresql.base import DatabaseWrapper
 
 
 class TestDatabaseWrapper(TestCase):
-    def test_warning_with_pool(self):
+    async def test_warning_with_pool(self):
         connection = async_connections[DEFAULT_DB_ALIAS]
 
         settings_dict = connection.settings_dict.copy()
@@ -17,7 +17,7 @@ class TestDatabaseWrapper(TestCase):
         with self.assertWarns(RuntimeWarning):
             DatabaseWrapper(settings_dict).get_connection_params()
 
-    def test_no_warning_without_pool(self):
+    async def test_no_warning_without_pool(self):
         connection = async_connections[DEFAULT_DB_ALIAS]
 
         settings_dict = connection.settings_dict.copy()
@@ -35,7 +35,7 @@ class TestDatabaseWrapper(TestCase):
             "RuntimeWarning was raised even though pool option is not enabled.",
         )
 
-    def test_no_warning_when_pool_warning_disabled(self):
+    async def test_no_warning_when_pool_warning_disabled(self):
         connection = async_connections[DEFAULT_DB_ALIAS]
 
         settings_dict = connection.settings_dict.copy()

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 from django.db import (
@@ -590,3 +591,115 @@ class IndependentConnectionTransaction(AsyncioTransactionTestCase):
                         await create_instance(2)
 
                         self.assertEqual(len(await get_all()), 1)
+
+
+class ConcurrentAsyncAtomicTests(AsyncioTransactionTestCase):
+    """
+    Child tasks that inherit a parent's connection via ContextVar can corrupt
+    transaction state or silently lose writes when sharing the same psycopg
+    async connection. validate_task_sharing, called on every
+    cursor/commit/rollback, rejects such sharing with a RuntimeError
+    (unless explicitly allowed via inc_task_sharing).
+    """
+
+    async def asyncSetUp(self):
+        await create_table()
+
+    async def asyncTearDown(self):
+        await drop_table()
+
+    async def test_fanout_create_task_atomic_raises(self):
+        """
+        A child task that opens async_atomic on the parent's
+        connection raises RuntimeError.
+        """
+
+        async def writer():
+            async with async_atomic():
+                await create_instance("fanout")
+
+        with self.assertRaises(RuntimeError):
+            await asyncio.create_task(writer())
+
+    async def test_fanout_gather_atomic_raises(self):
+        """Fan-out pattern from issue #11: N gather'd tasks each open
+        their own async_atomic on the shared connection.
+
+        Proves validate_task_sharing short-circuits *every* child's
+        atomic entry rather than only the first one in sibling/audit
+        shape. Without strict sharing this would match issue #11's
+        ProgrammingError 'connection in transaction status INTRANS';
+        with strict sharing we expect clean DatabaseError instead.
+        """
+        barrier = asyncio.Barrier(5)
+
+        async def writer(i):
+            await barrier.wait()
+            async with async_atomic():
+                await create_instance(f"fanout{i}")
+
+        results = await asyncio.gather(
+            *(writer(i) for i in range(5)), return_exceptions=True
+        )
+
+        db_errors = [r for r in results if isinstance(r, RuntimeError)]
+        self.assertEqual(
+            len(db_errors),
+            5,
+            f"expected 5 RuntimeError, got {results!r}",
+        )
+        # Nothing persisted: the guard short-circuits before BEGIN.
+        self.assertEqual(await get_all(), [])
+
+    async def test_nested_savepoint_same_task_works(self):
+        """Nested async_atomic() in the same task is a savepoint."""
+        async with async_atomic():
+            await create_instance("outer")
+            async with async_atomic():
+                await create_instance("inner")
+
+        self.assertEqual(len(await get_all()), 2)
+
+    async def test_sequential_atomic_same_task_works(self):
+        """Sequential async_atomic() calls in the same task work."""
+        async with async_atomic():
+            await create_instance("first")
+        async with async_atomic():
+            await create_instance("second")
+
+        self.assertEqual(len(await get_all()), 2)
+
+    async def test_parent_atomic_avoids_corruption(self):
+        """Single parent async_atomic wrapping gather() works."""
+        barrier = asyncio.Barrier(10)
+
+        async def writer(task_id):
+            await barrier.wait()
+            await create_instance(f"p{task_id}")
+            await asyncio.sleep(0)
+
+        async with async_atomic():
+            results = await asyncio.gather(
+                *(writer(i) for i in range(10)), return_exceptions=True
+            )
+
+        self.assertEqual([r for r in results if isinstance(r, Exception)], [])
+        self.assertEqual(len(await get_all()), 10)
+
+    async def test_independent_connection_avoids_corruption(self):
+        """_independent_connection() per task avoids corruption."""
+        barrier = asyncio.Barrier(10)
+
+        async def writer(task_id):
+            await barrier.wait()
+            async with async_connections._independent_connection():
+                async with async_atomic():
+                    await create_instance(f"i{task_id}")
+                    await asyncio.sleep(0)
+
+        results = await asyncio.gather(
+            *(writer(i) for i in range(10)), return_exceptions=True
+        )
+
+        self.assertEqual([r for r in results if isinstance(r, Exception)], [])
+        self.assertEqual(len(await get_all()), 10)

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -1,0 +1,15 @@
+from django.db import DEFAULT_DB_ALIAS
+from django.test import TestCase
+
+from django_async_backend.db.utils import AsyncConnectionHandler
+
+
+class AsyncConnectionHandlerSyncTests(TestCase):
+    def test_cannot_create_async_connection_without_running_event_loop(self):
+        with self.assertRaises(RuntimeError) as cm:
+            AsyncConnectionHandler()[DEFAULT_DB_ALIAS]
+
+        self.assertEqual(
+            str(cm.exception),
+            "Cannot create an async connection without a running event loop.",
+        )

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,0 +1,39 @@
+from django_async_backend.db import async_connections
+from django_async_backend.db.transaction import async_atomic
+from django_async_backend.test import (
+    AsyncioTestCase,
+    AsyncioTransactionTestCase,
+)
+
+
+async def purge():
+    """App-level helper that uses async_atomic internally."""
+    async with async_atomic():
+        async with await async_connections["default"].cursor() as c:
+            await c.execute("DROP TABLE IF EXISTS demo")
+
+
+class DownCallsHelperMixin:
+    async def asyncSetUp(self):
+        async with await async_connections["default"].cursor() as c:
+            await c.execute("CREATE TABLE IF NOT EXISTS demo (id SERIAL)")
+
+    async def asyncTearDown(self):
+        # RuntimeError: "Using a transaction in a nested task is forbidden"
+        await purge()
+
+    async def test_thing(self):
+        async with await async_connections["default"].cursor() as c:
+            await c.execute("INSERT INTO demo DEFAULT VALUES")
+
+
+class AsyncioTransactionTestCaseTearDownCallsHelper(
+    DownCallsHelperMixin, AsyncioTransactionTestCase
+):
+    pass
+
+
+class AsyncioTestCaseTearDownCallsHelper(
+    DownCallsHelperMixin, AsyncioTestCase
+):
+    pass


### PR DESCRIPTION
## Summary by Sourcery

Enforce per-task ownership of async database connections to prevent cross-task use of async_atomic and potential transaction corruption, and align tests with the new safety guarantees.

Bug Fixes:
- Reject use of async_atomic on a connection created in a different asyncio task to avoid corrupted transaction state and lost writes.
- Disallow creating async database connections when no event loop is running, raising a clear RuntimeError instead.
- Ensure psycopg version detection tests are robust by clearing the cached version between checks and loosening the PostgreSQL version error message match.

Enhancements:
- Track the owning asyncio task on async database connections and validate it on transaction entry to enforce safe task/connection usage.
- Automatically refresh connection task ownership for async test methods in AsyncioTransactionTestCase subclasses so tests run under the correct task context.

Tests:
- Add concurrency-focused async_atomic tests covering fan-out patterns, nested and sequential usage, and independent connections across tasks.
- Add tests verifying async connections cannot be created without a running event loop.
- Convert certain PostgreSQL backend tests to async and update expectations to match the new behavior.