### PR TITLE
Add AsyncioRollbackTestCase for rollback-based mixed sync/async tests

### DIFF
--- a/django_async_backend/db/sync_bridge.py
+++ b/django_async_backend/db/sync_bridge.py
@@ -1,6 +1,13 @@
 """
 Sync-bridged async DatabaseWrapper used by AsyncioRollbackTestCase.
 
+Vendored from django-async-backend PR #20:
+https://github.com/Arfey/django-async-backend/pull/20
+
+Copied verbatim from upstream commit 6e9d8fe (branch
+``feat/asyncio-rollback-testcase``). Remove this file and import from
+``django_async_backend.db.sync_bridge`` once upstream merges.
+
 Routes every operation that would normally hit an async psycopg connection
 through Django's sync connection via ``sync_to_async``. This lets a Django
 ``TestCase`` wrap a single transaction around both sync ORM calls and code
@@ -19,6 +26,7 @@ Trade-offs (intentional):
   branch fires and nests savepoints on top of Django's own per-test
   savepoint. PostgreSQL is the source of truth for the savepoint stack.
 """
+
 import _thread
 import collections
 from contextlib import contextmanager
@@ -53,9 +61,9 @@ class _BridgedAsyncCursor:
         )
 
     async def executemany(self, sql, param_list):
-        return await sync_to_async(
-            self.cursor.executemany, thread_sensitive=True
-        )(sql, param_list)
+        return await sync_to_async(self.cursor.executemany, thread_sensitive=True)(
+            sql, param_list
+        )
 
     async def fetchone(self):
         return await sync_to_async(self.cursor.fetchone, thread_sensitive=True)()
@@ -66,9 +74,7 @@ class _BridgedAsyncCursor:
     async def fetchmany(self, size=None):
         if size is None:
             size = self.cursor.arraysize
-        return await sync_to_async(
-            self.cursor.fetchmany, thread_sensitive=True
-        )(size)
+        return await sync_to_async(self.cursor.fetchmany, thread_sensitive=True)(size)
 
     async def close(self):
         await sync_to_async(self.cursor.close, thread_sensitive=True)()
@@ -100,8 +106,7 @@ class SyncBridgedAsyncWrapper:
         Falling back to a fresh per-thread lookup defeats the bridge."""
         self.alias = alias
         self._sync = (
-            sync_conn if sync_conn is not None
-            else django_sync_connections[alias]
+            sync_conn if sync_conn is not None else django_sync_connections[alias]
         )
 
         # Async-side state machine fields read/written by async_atomic.
@@ -127,6 +132,9 @@ class SyncBridgedAsyncWrapper:
         # Required by code that introspects task ownership.
         self._task = None
 
+        # Lazy ``_BridgedOps`` proxy — see the ``ops`` property below.
+        self._ops_proxy = None
+
     # ----- Attributes that defer to the sync connection -----
 
     @property
@@ -147,7 +155,16 @@ class SyncBridgedAsyncWrapper:
 
     @property
     def ops(self):
-        return self._sync.ops
+        # Real ``AsyncDatabaseOperations`` exposes an async ``compose_sql``;
+        # callers in async-only code paths ``await`` it. The sync ops
+        # only has a sync version that internally opens a cursor — calling
+        # it from inside an async context trips Django's
+        # ``SynchronousOnlyOperation`` guard. Wrap with a thin proxy that
+        # offers the async surface (compose_sql) and falls back to sync
+        # ops for everything else.
+        if self._ops_proxy is None:
+            self._ops_proxy = _BridgedOps(self._sync.ops)
+        return self._ops_proxy
 
     @property
     def Database(self):
@@ -253,10 +270,7 @@ class SyncBridgedAsyncWrapper:
         await self._exec_on_sync(self._sync.ops.savepoint_commit_sql(sid))
 
     async def _savepoint_allowed(self):
-        return (
-            self._sync.features.uses_savepoints
-            and not await self.get_autocommit()
-        )
+        return self._sync.features.uses_savepoints and not await self.get_autocommit()
 
     async def savepoint(self):
         if not await self._savepoint_allowed():
@@ -356,6 +370,30 @@ class SyncBridgedAsyncWrapper:
             raise TypeError("on_commit()'s callback must be a callable.")
         if self.in_atomic_block:
             self.run_on_commit.append((set(self.savepoint_ids), func, robust))
+
+
+class _BridgedOps:
+    """Proxies sync ``DatabaseOperations`` and exposes an async ``compose_sql``.
+
+    Real ``AsyncDatabaseOperations`` from ``django_async_backend.db.backends.postgresql``
+    has ``async def compose_sql`` so callers do
+    ``await conn.ops.compose_sql(sql, params)``. The sync postgres ops
+    only has a sync version that opens a cursor inline; calling it from
+    an async context raises ``SynchronousOnlyOperation``. This proxy
+    wraps the sync method in ``sync_to_async`` so the async-only code
+    paths in user code don't have to special-case the bridge.
+    """
+
+    def __init__(self, sync_ops):
+        self._sync_ops = sync_ops
+
+    async def compose_sql(self, sql, params):
+        return await sync_to_async(
+            self._sync_ops.compose_sql, thread_sensitive=True
+        )(sql, params)
+
+    def __getattr__(self, name):
+        return getattr(self._sync_ops, name)
 
 
 class _NoopErrorWrapper:

--- a/django_async_backend/db/sync_bridge.py
+++ b/django_async_backend/db/sync_bridge.py
@@ -1,0 +1,377 @@
+"""
+Sync-bridged async DatabaseWrapper used by AsyncioRollbackTestCase.
+
+Routes every operation that would normally hit an async psycopg connection
+through Django's sync connection via ``sync_to_async``. This lets a Django
+``TestCase`` wrap a single transaction around both sync ORM calls and code
+that uses ``async_connections`` for raw async SQL, so test-end rollback
+covers everything.
+
+Trade-offs (intentional):
+
+- All async I/O is forced onto a sync_to_async worker thread. There is no
+  real concurrency between two tasks using the bridged connection — they
+  serialize through Django's sync wrapper. This is fine for tests; it
+  would not be fine for production.
+- ``async_atomic`` creates savepoints on the sync connection. The TestCase
+  has already opened a transaction (autocommit=False on the sync conn),
+  so async_atomic's "already in a transaction at the connection level"
+  branch fires and nests savepoints on top of Django's own per-test
+  savepoint. PostgreSQL is the source of truth for the savepoint stack.
+"""
+import _thread
+import collections
+from contextlib import contextmanager
+
+from asgiref.sync import sync_to_async
+from django.db import connections as django_sync_connections
+from django.db.transaction import TransactionManagementError
+
+
+class _BridgedAsyncCursor:
+    """Mimics AsyncCursorWrapper but delegates to a sync cursor.
+
+    Only the methods that user code calls on the cursor are implemented.
+    """
+
+    def __init__(self, sync_cursor, db):
+        self.cursor = sync_cursor
+        self.db = db
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            await sync_to_async(self.cursor.close, thread_sensitive=True)()
+        except Exception:
+            pass
+
+    async def execute(self, sql, params=None):
+        return await sync_to_async(self.cursor.execute, thread_sensitive=True)(
+            sql, params
+        )
+
+    async def executemany(self, sql, param_list):
+        return await sync_to_async(
+            self.cursor.executemany, thread_sensitive=True
+        )(sql, param_list)
+
+    async def fetchone(self):
+        return await sync_to_async(self.cursor.fetchone, thread_sensitive=True)()
+
+    async def fetchall(self):
+        return await sync_to_async(self.cursor.fetchall, thread_sensitive=True)()
+
+    async def fetchmany(self, size=None):
+        if size is None:
+            size = self.cursor.arraysize
+        return await sync_to_async(
+            self.cursor.fetchmany, thread_sensitive=True
+        )(size)
+
+    async def close(self):
+        await sync_to_async(self.cursor.close, thread_sensitive=True)()
+
+    @property
+    def rowcount(self):
+        return self.cursor.rowcount
+
+    @property
+    def description(self):
+        return self.cursor.description
+
+    @property
+    def lastrowid(self):
+        return self.cursor.lastrowid
+
+
+class SyncBridgedAsyncWrapper:
+    """Drop-in for AsyncDatabaseWrapper that runs everything on the sync conn.
+
+    State the async transaction machinery reads/writes (``in_atomic_block``,
+    ``savepoint_ids``, etc.) lives on this proxy as plain attributes. Actual
+    SQL — including SAVEPOINT statements — is dispatched to the sync conn.
+    """
+
+    def __init__(self, alias, sync_conn=None):
+        """``sync_conn`` should be the Django sync connection captured on
+        the main test thread — the one TestCase opened its transaction on.
+        Falling back to a fresh per-thread lookup defeats the bridge."""
+        self.alias = alias
+        self._sync = (
+            sync_conn if sync_conn is not None
+            else django_sync_connections[alias]
+        )
+
+        # Async-side state machine fields read/written by async_atomic.
+        # Initialized fresh per test class (see AsyncioRollbackTestCase).
+        self.in_atomic_block = False
+        self.savepoint_state = 0
+        self.savepoint_ids = []
+        self.atomic_blocks = []
+        self.commit_on_exit = True
+        self.needs_rollback = False
+        self.rollback_exc = None
+        self.closed_in_transaction = False
+
+        self.execute_wrappers = []
+        self.queries_log = collections.deque(maxlen=9000)
+        self.force_debug_cursor = False
+        self.run_on_commit = []
+        self.run_commit_hooks_on_set_autocommit_on = False
+        self.errors_occurred = False
+        self.health_check_done = True
+        self.health_check_enabled = False
+
+        # Required by code that introspects task ownership.
+        self._task = None
+
+    # ----- Attributes that defer to the sync connection -----
+
+    @property
+    def vendor(self):
+        return self._sync.vendor
+
+    @property
+    def display_name(self):
+        return self._sync.display_name
+
+    @property
+    def settings_dict(self):
+        return self._sync.settings_dict
+
+    @property
+    def features(self):
+        return self._sync.features
+
+    @property
+    def ops(self):
+        return self._sync.ops
+
+    @property
+    def Database(self):
+        return self._sync.Database
+
+    @property
+    def connection(self):
+        # Truthy whenever the sync conn is open. async_atomic checks this in
+        # the closed_in_transaction branch.
+        return self._sync.connection
+
+    @connection.setter
+    def connection(self, value):
+        # async_atomic only ever sets this back to None on a closed_in_tx exit;
+        # we route that to the sync conn.
+        self._sync.connection = value
+
+    @property
+    def autocommit(self):
+        return self._sync.autocommit
+
+    @autocommit.setter
+    def autocommit(self, value):
+        # async_atomic mirrors what get_autocommit returned. Don't actually
+        # change the sync conn — TestCase owns its autocommit state.
+        pass
+
+    @property
+    def queries_logged(self):
+        return self.force_debug_cursor
+
+    @property
+    def queries(self):
+        return list(self.queries_log)
+
+    # ----- Connection lifecycle -----
+
+    async def ensure_connection(self):
+        if self._sync.connection is None:
+            await sync_to_async(self._sync.ensure_connection, thread_sensitive=True)()
+
+    async def close(self):
+        # Don't actually close the sync conn — TestCase owns it.
+        return
+
+    async def close_if_health_check_failed(self):
+        return
+
+    async def close_if_unusable_or_obsolete(self):
+        return
+
+    async def get_database_version(self):
+        return await sync_to_async(
+            self._sync.get_database_version, thread_sensitive=True
+        )()
+
+    async def check_database_version_supported(self):
+        return
+
+    # ----- Transaction primitives -----
+
+    async def get_autocommit(self):
+        await self.ensure_connection()
+        return self._sync.autocommit
+
+    async def set_autocommit(
+        self, autocommit, force_begin_transaction_with_broken_autocommit=False
+    ):
+        # No-op: TestCase controls autocommit on the sync conn. async_atomic
+        # only calls this when entering/leaving its outermost block; in our
+        # context async_atomic detects autocommit is already off and uses
+        # the savepoint code path instead.
+        return
+
+    async def commit(self):
+        # No-op: TestCase will rollback the outer transaction.
+        self.errors_occurred = False
+        self.run_commit_hooks_on_set_autocommit_on = True
+
+    async def rollback(self):
+        self.errors_occurred = False
+        self.needs_rollback = False
+        self.run_on_commit = []
+
+    # ----- Savepoints (route to the underlying sync conn) -----
+
+    async def _exec_on_sync(self, sql):
+        sync = self._sync
+
+        def _run():
+            with sync.cursor() as cursor:
+                cursor.execute(sql)
+
+        await sync_to_async(_run, thread_sensitive=True)()
+
+    async def _savepoint(self, sid):
+        await self._exec_on_sync(self._sync.ops.savepoint_create_sql(sid))
+
+    async def _savepoint_rollback(self, sid):
+        await self._exec_on_sync(self._sync.ops.savepoint_rollback_sql(sid))
+
+    async def _savepoint_commit(self, sid):
+        await self._exec_on_sync(self._sync.ops.savepoint_commit_sql(sid))
+
+    async def _savepoint_allowed(self):
+        return (
+            self._sync.features.uses_savepoints
+            and not await self.get_autocommit()
+        )
+
+    async def savepoint(self):
+        if not await self._savepoint_allowed():
+            return
+        thread_ident = _thread.get_ident()
+        tid = str(thread_ident).replace("-", "")
+        self.savepoint_state += 1
+        # `as_` prefix avoids any chance of collision with sync-side savepoint
+        # names that share the same scheme.
+        sid = "as_%s_x%d" % (tid, self.savepoint_state)
+        await self._savepoint(sid)
+        return sid
+
+    async def savepoint_rollback(self, sid):
+        if not await self._savepoint_allowed():
+            return
+        await self._savepoint_rollback(sid)
+        self.run_on_commit = [
+            (sids, func, robust)
+            for (sids, func, robust) in self.run_on_commit
+            if sid not in sids
+        ]
+
+    async def savepoint_commit(self, sid):
+        if not await self._savepoint_allowed():
+            return
+        await self._savepoint_commit(sid)
+
+    def clean_savepoints(self):
+        self.savepoint_state = 0
+
+    # ----- Cursor -----
+
+    async def cursor(self):
+        await self.ensure_connection()
+        sync_cursor = await sync_to_async(self._sync.cursor, thread_sensitive=True)()
+        return _BridgedAsyncCursor(sync_cursor, self)
+
+    def chunked_cursor(self):
+        return self.cursor()
+
+    # ----- Validation helpers (called by async_atomic / cursor paths) -----
+
+    def validate_thread_sharing(self):
+        # We've called inc_thread_sharing on the sync conn for the test
+        # class duration; allow async-side use freely.
+        return
+
+    def validate_no_atomic_block(self):
+        if self.in_atomic_block:
+            raise TransactionManagementError(
+                "This is forbidden when an 'atomic' block is active."
+            )
+
+    def validate_no_broken_transaction(self):
+        if self.needs_rollback:
+            raise TransactionManagementError(
+                "An error occurred in the current transaction. You can't "
+                "execute queries until the end of the 'atomic' block."
+            ) from self.rollback_exc
+
+    def get_rollback(self):
+        if not self.in_atomic_block:
+            raise TransactionManagementError(
+                "The rollback flag doesn't work outside of an 'atomic' block."
+            )
+        return self.needs_rollback
+
+    def set_rollback(self, rollback):
+        if not self.in_atomic_block:
+            raise TransactionManagementError(
+                "The rollback flag doesn't work outside of an 'atomic' block."
+            )
+        self.needs_rollback = rollback
+
+    @property
+    def wrap_database_errors(self):
+        # Use the sync conn's error wrapper — it knows the right exception
+        # types for the underlying driver.
+        return _NoopErrorWrapper()
+
+    @contextmanager
+    def execute_wrapper(self, wrapper):
+        self.execute_wrappers.append(wrapper)
+        try:
+            yield
+        finally:
+            self.execute_wrappers.pop()
+
+    async def on_commit(self, func, robust=False):
+        # Inside a TestCase the outer transaction is rolled back, so on_commit
+        # callbacks never fire. Match Django's TestCase.captureOnCommitCallbacks
+        # semantics: queue them on the run_on_commit list with the active
+        # savepoint set; users can opt into a captureOnCommitCallbacks helper
+        # if they want to assert they were registered.
+        if not callable(func):
+            raise TypeError("on_commit()'s callback must be a callable.")
+        if self.in_atomic_block:
+            self.run_on_commit.append((set(self.savepoint_ids), func, robust))
+
+
+class _NoopErrorWrapper:
+    """No-op replacement for DatabaseErrorWrapper.
+
+    Django's sync error wrapper translates psycopg exceptions into Django's
+    common DB exception hierarchy. Our bridged cursor calls run inside
+    sync_to_async on the sync wrapper which already does its own error
+    translation, so we don't need a second layer here.
+    """
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __call__(self, fn):
+        return fn

--- a/django_async_backend/db/sync_bridge.py
+++ b/django_async_backend/db/sync_bridge.py
@@ -4,7 +4,7 @@ Sync-bridged async DatabaseWrapper used by AsyncioRollbackTestCase.
 Vendored from django-async-backend PR #20:
 https://github.com/Arfey/django-async-backend/pull/20
 
-Copied verbatim from upstream commit 6e9d8fe (branch
+Copied verbatim from upstream commit ea07ec8 (branch
 ``feat/asyncio-rollback-testcase``). Remove this file and import from
 ``django_async_backend.db.sync_bridge`` once upstream merges.
 
@@ -50,6 +50,7 @@ class _BridgedAsyncCursor:
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
         try:
             await sync_to_async(self.cursor.close, thread_sensitive=True)()
         except Exception:
@@ -237,6 +238,7 @@ class SyncBridgedAsyncWrapper:
         # only calls this when entering/leaving its outermost block; in our
         # context async_atomic detects autocommit is already off and uses
         # the savepoint code path instead.
+        del autocommit, force_begin_transaction_with_broken_autocommit
         return
 
     async def commit(self):
@@ -388,9 +390,9 @@ class _BridgedOps:
         self._sync_ops = sync_ops
 
     async def compose_sql(self, sql, params):
-        return await sync_to_async(
-            self._sync_ops.compose_sql, thread_sensitive=True
-        )(sql, params)
+        return await sync_to_async(self._sync_ops.compose_sql, thread_sensitive=True)(
+            sql, params
+        )
 
     def __getattr__(self, name):
         return getattr(self._sync_ops, name)
@@ -409,6 +411,7 @@ class _NoopErrorWrapper:
         return self
 
     def __exit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
         return False
 
     def __call__(self, fn):

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -105,89 +105,131 @@ class AsyncioRollbackTestCase(DjangoTestCase):
     """Django ``TestCase`` that also rolls back ``async_connections`` writes.
 
     Routes every ``async_connections[alias]`` operation through Django's sync
-    connection for the duration of the test. The single transaction Django
-    opens around the class then covers writes done via either pool, and
-    per-test savepoints roll both back together.
+    connection for the duration of the test class. The single transaction
+    Django opens around the class then covers writes done via either pool,
+    and per-test savepoints roll both back together.
+
+    The proxy is installed at ``setUpClass`` by swapping
+    ``async_connections._connections`` (and Django's
+    ``connections._connections``) to thread-blind ``SimpleNamespace``\\s
+    for the class duration. That means even sync test methods that drive
+    async code through ``async_to_sync(...)`` see the proxy on the worker
+    thread — without that swap, the worker resolves a fresh per-thread
+    async connection that opens its own autocommit transaction.
 
     Async test methods (``async def test_*``) are run via ``async_to_sync``;
     optional ``asyncSetUp`` / ``asyncTearDown`` hooks share the same event
-    loop and task as the test method.
+    loop and task as the test method. Sync test methods run as Django's
+    own ``TestCase`` would.
+
+    Tradeoff: there's no real concurrency between two tasks using the
+    bridged connection during a test — they serialise through Django's
+    sync wrapper. Same shape as Django's regular TestCase semantics
+    (one transaction, no parallelism). Production keeps its real async
+    pool unchanged.
     """
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Allow the dedicated async_to_sync worker thread to use the sync conn
-        # opened on the main test thread.
-        for alias in cls._databases_names(include_mirrors=False):
-            django_sync_connections[alias].inc_thread_sharing()
+        aliases = list(cls._databases_names(include_mirrors=False))
+        sync_conns = {
+            alias: django_sync_connections[alias] for alias in aliases
+        }
 
-    @classmethod
-    def tearDownClass(cls):
-        for alias in cls._databases_names(include_mirrors=False):
-            django_sync_connections[alias].dec_thread_sharing()
-        super().tearDownClass()
+        # Allow worker threads spawned by ``async_to_sync`` to use the
+        # sync conn opened on the main thread.
+        for conn in sync_conns.values():
+            conn.inc_thread_sharing()
 
-    def _callTestMethod(self, method):
-        # Django's SimpleTestCase.__call__ has already wrapped async test
-        # methods with async_to_sync, so ``method`` here is sync. Look at
-        # the original on the class to decide which path to take.
-        raw = getattr(type(self), self._testMethodName, None)
-        if asyncio.iscoroutinefunction(raw):
-            sync_conns = {
-                alias: django_sync_connections[alias]
-                for alias in type(self)._databases_names(include_mirrors=False)
-            }
-            async_to_sync(self._run_async_test)(
-                raw.__get__(self, type(self)), sync_conns
-            )
-        else:
-            super()._callTestMethod(method)
-
-    async def _run_async_test(self, method, sync_conns):
         proxies = {
             alias: SyncBridgedAsyncWrapper(alias, sync_conn=conn)
             for alias, conn in sync_conns.items()
         }
+        cls._async_rollback_proxies = proxies
 
-        # Make sync_to_async calls inside this test see the same Django
-        # sync wrapper the TestCase opened its transaction on. Django's
-        # default connections._connections is thread-local; swapping in a
-        # plain SimpleNamespace makes it thread-blind for the test's
-        # duration so the asgiref worker thread reuses the main wrapper
-        # instead of opening a new autocommit connection.
-        sync_conn_storage = types.SimpleNamespace(**sync_conns)
-        original_sync_storage = django_sync_connections._connections
-        django_sync_connections._connections = sync_conn_storage
+        # Swap both connection stores for thread-blind SimpleNamespaces.
+        # ``django_sync_connections._connections`` is normally an
+        # asgiref.Local → ContextVar; the SimpleNamespace makes the
+        # asgiref worker thread reuse the same wrapper instead of
+        # opening its own autocommit connection. Same trick for
+        # ``async_connections._connections`` so any task accessing
+        # ``async_connections[alias]`` — main thread or worker — gets
+        # the proxy.
+        cls._async_rollback_orig_sync_storage = (
+            django_sync_connections._connections
+        )
+        django_sync_connections._connections = types.SimpleNamespace(
+            **sync_conns
+        )
 
+        cls._async_rollback_orig_async_storage = (
+            async_connections._connections
+        )
+        async_connections._connections = types.SimpleNamespace(**proxies)
+
+    @classmethod
+    def tearDownClass(cls):
+        async_connections._connections = (
+            cls._async_rollback_orig_async_storage
+        )
+        django_sync_connections._connections = (
+            cls._async_rollback_orig_sync_storage
+        )
+        for alias in cls._databases_names(include_mirrors=False):
+            django_sync_connections[alias].dec_thread_sharing()
+        super().tearDownClass()
+
+    def _reset_proxy_state(self):
+        """Reset per-test mutable state on every proxy.
+
+        The class-scope proxies persist for the whole class; their
+        atomic/savepoint bookkeeping needs to start fresh for each
+        test method (Django's ``TestCase`` opens a per-test savepoint
+        on the sync conn separately).
+        """
+        for proxy in self._async_rollback_proxies.values():
+            proxy.in_atomic_block = False
+            proxy.savepoint_state = 0
+            proxy.savepoint_ids = []
+            proxy.atomic_blocks = []
+            proxy.commit_on_exit = True
+            proxy.needs_rollback = False
+            proxy.rollback_exc = None
+            proxy.run_on_commit = []
+            proxy._task = None
+
+    def _callTestMethod(self, method):
+        self._reset_proxy_state()
+
+        # Django's SimpleTestCase.__call__ has already wrapped async
+        # test methods with async_to_sync, so ``method`` here is sync.
+        # Look at the original on the class to decide which path to take.
+        raw = getattr(type(self), self._testMethodName, None)
+        if asyncio.iscoroutinefunction(raw):
+            async_to_sync(self._run_async_test)(
+                raw.__get__(self, type(self))
+            )
+        else:
+            # Sync test method. Anything inside that calls
+            # ``async_to_sync(some_async)`` will run on the asgiref
+            # worker thread — the SimpleNamespace storage swap means
+            # it still sees the proxies installed in setUpClass.
+            super()._callTestMethod(method)
+
+    async def _run_async_test(self, method):
         current_task = asyncio.current_task()
-        originals = {}
-        for alias, proxy in proxies.items():
+        for proxy in self._async_rollback_proxies.values():
             proxy._task = current_task
-            try:
-                originals[alias] = getattr(
-                    async_connections._connections, alias
-                )
-            except AttributeError:
-                originals[alias] = None
-            setattr(async_connections._connections, alias, proxy)
-        try:
-            async_setup = getattr(self, "asyncSetUp", None)
-            if asyncio.iscoroutinefunction(async_setup):
-                await async_setup()
-            if method is not None:
-                await method()
-            async_teardown = getattr(self, "asyncTearDown", None)
-            if asyncio.iscoroutinefunction(async_teardown):
-                await async_teardown()
-        finally:
-            for alias, original in originals.items():
-                if original is None:
-                    if hasattr(async_connections._connections, alias):
-                        delattr(async_connections._connections, alias)
-                else:
-                    setattr(async_connections._connections, alias, original)
-            django_sync_connections._connections = original_sync_storage
+
+        async_setup = getattr(self, "asyncSetUp", None)
+        if asyncio.iscoroutinefunction(async_setup):
+            await async_setup()
+        if method is not None:
+            await method()
+        async_teardown = getattr(self, "asyncTearDown", None)
+        if asyncio.iscoroutinefunction(async_teardown):
+            await async_teardown()
 
 
 class AsyncCaptureQueriesContext:

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -1,11 +1,16 @@
 import asyncio
+import types
 from functools import wraps
 from unittest import IsolatedAsyncioTestCase
 
+from asgiref.sync import async_to_sync
 from django.core.signals import request_started
+from django.db import connections as django_sync_connections
 from django.db import reset_queries
+from django.test import TestCase as DjangoTestCase
 
 from django_async_backend.db import async_connections
+from django_async_backend.db.sync_bridge import SyncBridgedAsyncWrapper
 from django_async_backend.db.transaction import async_atomic
 
 
@@ -94,6 +99,95 @@ class AsyncioTestCase(AsyncioTransactionTestCase):
         )
         self._callAsync(self._close_transaction)
         self._asyncioTestContext.run(self.tearDown)
+
+
+class AsyncioRollbackTestCase(DjangoTestCase):
+    """Django ``TestCase`` that also rolls back ``async_connections`` writes.
+
+    Routes every ``async_connections[alias]`` operation through Django's sync
+    connection for the duration of the test. The single transaction Django
+    opens around the class then covers writes done via either pool, and
+    per-test savepoints roll both back together.
+
+    Async test methods (``async def test_*``) are run via ``async_to_sync``;
+    optional ``asyncSetUp`` / ``asyncTearDown`` hooks share the same event
+    loop and task as the test method.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Allow the dedicated async_to_sync worker thread to use the sync conn
+        # opened on the main test thread.
+        for alias in cls._databases_names(include_mirrors=False):
+            django_sync_connections[alias].inc_thread_sharing()
+
+    @classmethod
+    def tearDownClass(cls):
+        for alias in cls._databases_names(include_mirrors=False):
+            django_sync_connections[alias].dec_thread_sharing()
+        super().tearDownClass()
+
+    def _callTestMethod(self, method):
+        # Django's SimpleTestCase.__call__ has already wrapped async test
+        # methods with async_to_sync, so ``method`` here is sync. Look at
+        # the original on the class to decide which path to take.
+        raw = getattr(type(self), self._testMethodName, None)
+        if asyncio.iscoroutinefunction(raw):
+            sync_conns = {
+                alias: django_sync_connections[alias]
+                for alias in type(self)._databases_names(include_mirrors=False)
+            }
+            async_to_sync(self._run_async_test)(
+                raw.__get__(self, type(self)), sync_conns
+            )
+        else:
+            super()._callTestMethod(method)
+
+    async def _run_async_test(self, method, sync_conns):
+        proxies = {
+            alias: SyncBridgedAsyncWrapper(alias, sync_conn=conn)
+            for alias, conn in sync_conns.items()
+        }
+
+        # Make sync_to_async calls inside this test see the same Django
+        # sync wrapper the TestCase opened its transaction on. Django's
+        # default connections._connections is thread-local; swapping in a
+        # plain SimpleNamespace makes it thread-blind for the test's
+        # duration so the asgiref worker thread reuses the main wrapper
+        # instead of opening a new autocommit connection.
+        sync_conn_storage = types.SimpleNamespace(**sync_conns)
+        original_sync_storage = django_sync_connections._connections
+        django_sync_connections._connections = sync_conn_storage
+
+        current_task = asyncio.current_task()
+        originals = {}
+        for alias, proxy in proxies.items():
+            proxy._task = current_task
+            try:
+                originals[alias] = getattr(
+                    async_connections._connections, alias
+                )
+            except AttributeError:
+                originals[alias] = None
+            setattr(async_connections._connections, alias, proxy)
+        try:
+            async_setup = getattr(self, "asyncSetUp", None)
+            if asyncio.iscoroutinefunction(async_setup):
+                await async_setup()
+            if method is not None:
+                await method()
+            async_teardown = getattr(self, "asyncTearDown", None)
+            if asyncio.iscoroutinefunction(async_teardown):
+                await async_teardown()
+        finally:
+            for alias, original in originals.items():
+                if original is None:
+                    if hasattr(async_connections._connections, alias):
+                        delattr(async_connections._connections, alias)
+                else:
+                    setattr(async_connections._connections, alias, original)
+            django_sync_connections._connections = original_sync_storage
 
 
 class AsyncCaptureQueriesContext:

--- a/tests/test_rollback_testcase.py
+++ b/tests/test_rollback_testcase.py
@@ -1,0 +1,219 @@
+"""
+Tests for AsyncioRollbackTestCase.
+
+Covers four shapes:
+  1. async_connections write inside a plain Django TestCase leaks past rollback
+     (the gap that motivated the new class).
+  2. async_connections write inside AsyncioRollbackTestCase is rolled back.
+  3. Sync ORM write + async_connections write in the same test both roll back
+     and see each other's uncommitted data.
+  4. async_atomic creates a savepoint and rolls back independently of the
+     outer test transaction.
+"""
+import asyncio
+
+from django.db import DEFAULT_DB_ALIAS, connection
+from django.test import TestCase
+
+from django_async_backend.db import async_connections
+from django_async_backend.db.transaction import async_atomic
+from django_async_backend.test import AsyncioRollbackTestCase
+
+
+class StandardTestCaseLeaksAsyncWrites(TestCase):
+    """A plain Django TestCase does NOT cover async_connections writes.
+
+    This is the gap. The test inserts a row via async_connections inside a
+    TestCase, the TestCase rolls back at end-of-test, and the row is still
+    in the database afterward. tearDownClass cleans it up so we don't
+    poison other tests.
+    """
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        # Run after the class transaction is closed; touches the real table.
+        with connection.cursor() as c:
+            c.execute("DELETE FROM test_model WHERE name LIKE 'leak-demo-%'")
+        # Tear down any async connections opened by this test so the test
+        # DB can be dropped at suite teardown.
+        async def _close_async():
+            for alias in async_connections.settings.keys():
+                await async_connections[alias].close()
+
+        asyncio.run(_close_async())
+
+    def test_async_write_leaks_past_testcase_rollback(self):
+        async def _insert():
+            async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+                await c.execute(
+                    "INSERT INTO test_model (name) VALUES ('leak-demo-1')"
+                )
+            # Async pool defaults to autocommit=True, so the row commits.
+            await async_connections[DEFAULT_DB_ALIAS].close()
+
+        asyncio.run(_insert())
+
+        # Verify the row is committed-and-visible from a fresh async session.
+        # If async_connections shared a transaction with the sync conn, the
+        # row would NOT have committed and a fresh session would see 0.
+        async def _count():
+            try:
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as c:
+                    await c.execute(
+                        "SELECT count(*) FROM test_model "
+                        "WHERE name = 'leak-demo-1'"
+                    )
+                    row = await c.fetchone()
+                    return row[0]
+            finally:
+                await async_connections[DEFAULT_DB_ALIAS].close()
+
+        self.assertEqual(asyncio.run(_count()), 1)
+
+
+class RollbackCoversAsyncWrites(AsyncioRollbackTestCase):
+    """AsyncioRollbackTestCase routes async writes through the sync conn,
+    so the TestCase rollback covers them."""
+
+    async def test_async_write_visible_then_rolled_back(self):
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "INSERT INTO test_model (name) VALUES ('rollback-demo-1')"
+            )
+            await c.execute(
+                "SELECT count(*) FROM test_model "
+                "WHERE name = 'rollback-demo-1'"
+            )
+            row = await c.fetchone()
+            self.assertEqual(row[0], 1)
+
+
+class RollbackCoversNothingPersists(AsyncioRollbackTestCase):
+    """Run after RollbackCoversAsyncWrites; verifies the prior test's row
+    did not leak into this test's view."""
+
+    async def test_no_rows_present(self):
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "SELECT count(*) FROM test_model "
+                "WHERE name = 'rollback-demo-1'"
+            )
+            row = await c.fetchone()
+            self.assertEqual(row[0], 0)
+
+
+class MixedSyncAndAsyncWrites(AsyncioRollbackTestCase):
+    """Sync write via Django connection + async raw SQL share the test
+    transaction. Each side sees the other's uncommitted writes; both
+    roll back together."""
+
+    async def test_sync_then_async_visible_to_each_other(self):
+        from asgiref.sync import sync_to_async
+
+        def _sync_write():
+            with connection.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO test_model (name) VALUES ('from-sync')"
+                )
+
+        await sync_to_async(_sync_write)()
+
+        # Async raw insert (goes to the same sync conn via the bridge).
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "INSERT INTO test_model (name) VALUES ('from-async')"
+            )
+
+        # Both rows visible from the async side.
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "SELECT count(*) FROM test_model "
+                "WHERE name IN ('from-sync', 'from-async')"
+            )
+            row = await c.fetchone()
+            self.assertEqual(row[0], 2)
+
+        # And from the sync side.
+        def _sync_count():
+            with connection.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) FROM test_model "
+                    "WHERE name IN ('from-sync', 'from-async')"
+                )
+                return cur.fetchone()[0]
+
+        self.assertEqual(await sync_to_async(_sync_count)(), 2)
+
+
+class AsyncAtomicSavepointBehavior(AsyncioRollbackTestCase):
+    """async_atomic should create a savepoint inside the TestCase
+    transaction and roll back independently."""
+
+    async def test_async_atomic_rollback_only_affects_inner_block(self):
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "INSERT INTO test_model (name) VALUES ('outer-row')"
+            )
+
+        try:
+            async with async_atomic():
+                async with await async_connections[
+                    DEFAULT_DB_ALIAS
+                ].cursor() as c:
+                    await c.execute(
+                        "INSERT INTO test_model (name) "
+                        "VALUES ('inner-row')"
+                    )
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "SELECT name FROM test_model "
+                "WHERE name IN ('outer-row', 'inner-row') "
+                "ORDER BY name"
+            )
+            rows = await c.fetchall()
+            self.assertEqual([r[0] for r in rows], ["outer-row"])
+
+    async def test_async_atomic_commit_keeps_inner_writes(self):
+        async with async_atomic():
+            async with await async_connections[
+                DEFAULT_DB_ALIAS
+            ].cursor() as c:
+                await c.execute(
+                    "INSERT INTO test_model (name) VALUES ('committed-inner')"
+                )
+
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "SELECT count(*) FROM test_model "
+                "WHERE name = 'committed-inner'"
+            )
+            row = await c.fetchone()
+            self.assertEqual(row[0], 1)
+
+
+class SetUpTestDataIsVisibleFromAsyncSide(AsyncioRollbackTestCase):
+    """setUpTestData runs in TestCase's outer transaction; async reads via
+    the bridge should see those rows."""
+
+    @classmethod
+    def setUpTestData(cls):
+        with connection.cursor() as cur:
+            cur.execute(
+                "INSERT INTO test_model (name) VALUES ('seeded-by-setup')"
+            )
+
+    async def test_seeded_row_visible_from_async(self):
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "SELECT count(*) FROM test_model "
+                "WHERE name = 'seeded-by-setup'"
+            )
+            row = await c.fetchone()
+            self.assertEqual(row[0], 1)

--- a/tests/test_rollback_testcase.py
+++ b/tests/test_rollback_testcase.py
@@ -198,6 +198,135 @@ class AsyncAtomicSavepointBehavior(AsyncioRollbackTestCase):
             self.assertEqual(row[0], 1)
 
 
+class CrossPoolAtomicSemanticsDivergence(AsyncioRollbackTestCase):
+    """REGRESSION (currently fails): the bridge gives different
+    cross-pool transaction semantics than production.
+
+    In production:
+    - ``async_atomic()`` operates on the async psycopg connection.
+    - ``sync_to_async(transaction.atomic)`` operates on Django's sync
+      psycopg connection.
+    - Two physical connections, two independent transactions. A sync
+      atomic block that commits its savepoint and a surrounding async
+      atomic that rolls back: sync write **persists**.
+
+    Under the bridge:
+    - ``async_connections[alias]`` is a proxy onto the sync conn.
+    - Both atomics write SAVEPOINT/RELEASE/ROLLBACK to the same
+      backend, but each tracks its own savepoint counter.
+    - The inner sync atomic's RELEASE doesn't tell the proxy
+      anything; the outer async atomic rolls back to its own
+      savepoint, which sits *under* the inner one in PG's stack —
+      undoing the inner sync write too.
+
+    This is the gap Arfey called out: the bridge asks tests to assert
+    on a behaviour the framework can't actually replicate, because two
+    state machines now share one connection. Document the limitation
+    here as a failing test until the bridge either grows
+    cross-state-machine coordination or the framework explicitly
+    forbids the mix.
+    """
+
+    async def test_inner_sync_atomic_persists_through_outer_async_rollback(self):
+        from asgiref.sync import sync_to_async
+        from django.db import transaction
+
+        def _sync_atomic_insert():
+            with transaction.atomic():
+                with connection.cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO test_model (name) "
+                        "VALUES ('mixed-atomic-sync')"
+                    )
+
+        try:
+            async with async_atomic():
+                await sync_to_async(_sync_atomic_insert)()
+                raise RuntimeError("trigger outer rollback")
+        except RuntimeError:
+            pass
+
+        # Production semantics (separate physical conns): the inner
+        # sync atomic committed its own savepoint on the sync conn, so
+        # the row persists despite the outer async_atomic rollback.
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "SELECT count(*) FROM test_model "
+                "WHERE name = 'mixed-atomic-sync'"
+            )
+            row = await c.fetchone()
+            self.assertEqual(
+                row[0],
+                1,
+                "Bridge collapses two physical connections into one, so the "
+                "outer async_atomic ROLLBACK undoes a sync atomic block that "
+                "had already RELEASEd its own savepoint. Production has "
+                "separate conns and the sync write persists.",
+            )
+
+
+class BridgeFlattersDoesNotMatchProduction(AsyncioRollbackTestCase):
+    """REGRESSION (currently passes — and that's the problem).
+
+    The inverse of ``CrossPoolAtomicSemanticsDivergence``: a test that
+    asserts the **bridge's** answer (rather than production's) gets a
+    green light, even though shipping the same code to a real
+    deployment would behave differently.
+
+    Concretely: outer ``async_atomic`` wraps an inner sync atomic
+    insert via ``sync_to_async``, then the outer block raises.
+
+    - Under the bridge: both atomics share one psycopg conn; the
+      outer ROLLBACK reverts the inner write. ``count == 0``.
+    - In production: async and sync are separate physical
+      connections; the inner sync atomic committed its savepoint
+      before the outer raised. ``count == 1``.
+
+    A test author who didn't know about the bridge could write
+    ``assertEqual(count, 0)`` here, watch CI go green, and ship a
+    code path that silently leaks rows in production. That's the
+    structural risk Arfey flagged: the bridge isn't just "covers
+    fewer scenarios", it actively models a different semantics.
+
+    The framework doesn't know which answer the test author meant —
+    it can't tell apart "I'm testing rollback covers everything"
+    from "I'm testing cross-pool isolation". So this passing-but-wrong
+    case has to be addressed at the framework contract level, not by
+    individual test authors being careful.
+    """
+
+    async def test_bridge_says_inner_sync_write_was_rolled_back(self):
+        from asgiref.sync import sync_to_async
+        from django.db import transaction
+
+        def _sync_atomic_insert():
+            with transaction.atomic():
+                with connection.cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO test_model (name) "
+                        "VALUES ('flatter-demo')"
+                    )
+
+        try:
+            async with async_atomic():
+                await sync_to_async(_sync_atomic_insert)()
+                raise RuntimeError("trigger outer rollback")
+        except RuntimeError:
+            pass
+
+        async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
+            await c.execute(
+                "SELECT count(*) FROM test_model "
+                "WHERE name = 'flatter-demo'"
+            )
+            row = await c.fetchone()
+            # Asserts the **bridge**'s answer. This is GREEN under
+            # AsyncioRollbackTestCase. Same code shipped to prod would
+            # observe ``row[0] == 1`` because the inner sync atomic
+            # commits independently on the sync connection.
+            self.assertEqual(row[0], 0)
+
+
 class SetUpTestDataIsVisibleFromAsyncSide(AsyncioRollbackTestCase):
     """setUpTestData runs in TestCase's outer transaction; async reads via
     the bridge should see those rows."""

--- a/tests/test_rollback_testcase.py
+++ b/tests/test_rollback_testcase.py
@@ -199,32 +199,78 @@ class AsyncAtomicSavepointBehavior(AsyncioRollbackTestCase):
 
 
 class CrossPoolAtomicSemanticsDivergence(AsyncioRollbackTestCase):
-    """REGRESSION (currently fails): the bridge gives different
-    cross-pool transaction semantics than production.
+    """REGRESSION (currently fails on purpose).
 
-    In production:
-    - ``async_atomic()`` operates on the async psycopg connection.
-    - ``sync_to_async(transaction.atomic)`` operates on Django's sync
-      psycopg connection.
-    - Two physical connections, two independent transactions. A sync
-      atomic block that commits its savepoint and a surrounding async
-      atomic that rolls back: sync write **persists**.
+    Demonstrates that ``AsyncioRollbackTestCase`` cannot model
+    cross-pool transaction semantics — the answers it gives for tests
+    that mix ``async_atomic`` and ``transaction.atomic`` differ from
+    what a real deployment of django-async-backend would observe.
 
-    Under the bridge:
-    - ``async_connections[alias]`` is a proxy onto the sync conn.
-    - Both atomics write SAVEPOINT/RELEASE/ROLLBACK to the same
-      backend, but each tracks its own savepoint counter.
-    - The inner sync atomic's RELEASE doesn't tell the proxy
-      anything; the outer async atomic rolls back to its own
-      savepoint, which sits *under* the inner one in PG's stack —
-      undoing the inner sync write too.
+    What the bridge actually does
+    -----------------------------
 
-    This is the gap Arfey called out: the bridge asks tests to assert
-    on a behaviour the framework can't actually replicate, because two
-    state machines now share one connection. Document the limitation
-    here as a failing test until the bridge either grows
-    cross-state-machine coordination or the framework explicitly
-    forbids the mix.
+    ``AsyncioRollbackTestCase`` replaces ``async_connections[alias]``
+    with a proxy that owns no real psycopg async connection. Every
+    cursor / savepoint call the proxy receives is dispatched, via
+    ``sync_to_async``, onto the same ``psycopg.Connection`` that
+    Django's ``TestCase`` opened a transaction on. The bridge also
+    swaps Django's ``connections._connections`` storage to a
+    thread-blind container pointing at that same wrapper. End result:
+    code that *thinks* it's on two separate connections is actually
+    sharing one TCP socket, one server-side backend, and one
+    transaction state.
+
+    What a real deployment looks like
+    ---------------------------------
+
+    Outside of a test, ``async_connections[alias]`` opens (or pulls
+    from a pool) its own ``psycopg.AsyncConnection``. ``connections[alias]``
+    opens a separate ``psycopg.Connection``. They are two distinct
+    connections to Postgres with two distinct backends and two
+    independent transaction stacks. A SAVEPOINT issued from
+    ``async_atomic()`` lives on connection A; a SAVEPOINT issued from
+    ``transaction.atomic()`` lives on connection B. Neither sees the
+    other's savepoint stack.
+
+    The shape this test exercises
+    -----------------------------
+
+    Outer ``async with async_atomic():`` wraps an inner
+    ``sync_to_async(_sync_atomic_insert)``, where the inner block
+    runs ``with transaction.atomic(): cursor.execute(INSERT)`` and
+    cleanly exits. The outer block then raises and triggers a
+    rollback.
+
+    In a real deployment, the inner sync atomic opens a savepoint on
+    the **sync** connection, runs the INSERT, and releases the
+    savepoint — which durably commits the row to the sync
+    connection's transaction (autocommit by default for sync code
+    outside an explicit ``transaction.atomic`` chain at the request
+    level). The outer ``async_atomic()``'s rollback then issues
+    ROLLBACK TO SAVEPOINT on the **async** connection, which has zero
+    effect on the sync connection. A subsequent SELECT — from any
+    connection — sees the row. That is the answer this test asserts:
+    ``count == 1``.
+
+    Under the bridge, the two atomics share one connection. The PG
+    savepoint stack mid-test ends up roughly:
+
+        [TestCase_class_savepoint,
+         async_atomic_savepoint,
+         transaction.atomic_savepoint,
+         INSERT,
+         RELEASE transaction.atomic_savepoint]
+
+    Then the outer block raises, the bridge issues
+    ``ROLLBACK TO SAVEPOINT async_atomic_savepoint``, and the INSERT
+    — which sits underneath that savepoint in PG's stack — is
+    reverted along with it. Bridge result: ``count == 0``.
+
+    The test asserts ``1`` (the deployed-app answer) and gets ``0``
+    (the bridge's), so it fails. The failure is not a bug in the
+    bridge implementation; it's a property of collapsing two
+    connections into one. No bookkeeping change inside the proxy can
+    fix it because Postgres still only sees one transaction stack.
     """
 
     async def test_inner_sync_atomic_persists_through_outer_async_rollback(self):
@@ -246,9 +292,6 @@ class CrossPoolAtomicSemanticsDivergence(AsyncioRollbackTestCase):
         except RuntimeError:
             pass
 
-        # Production semantics (separate physical conns): the inner
-        # sync atomic committed its own savepoint on the sync conn, so
-        # the row persists despite the outer async_atomic rollback.
         async with await async_connections[DEFAULT_DB_ALIAS].cursor() as c:
             await c.execute(
                 "SELECT count(*) FROM test_model "
@@ -258,41 +301,62 @@ class CrossPoolAtomicSemanticsDivergence(AsyncioRollbackTestCase):
             self.assertEqual(
                 row[0],
                 1,
-                "Bridge collapses two physical connections into one, so the "
-                "outer async_atomic ROLLBACK undoes a sync atomic block that "
-                "had already RELEASEd its own savepoint. Production has "
-                "separate conns and the sync write persists.",
+                "Bridge collapses two physical connections into one, so "
+                "the outer async_atomic ROLLBACK undoes a sync atomic "
+                "block that had already RELEASEd its own savepoint. A "
+                "real deployment has separate connections, the inner "
+                "sync atomic commits independently, and the row persists.",
             )
 
 
-class BridgeFlattersDoesNotMatchProduction(AsyncioRollbackTestCase):
+class BridgeFlattersDoesNotMatchDeployedApp(AsyncioRollbackTestCase):
     """REGRESSION (currently passes — and that's the problem).
 
-    The inverse of ``CrossPoolAtomicSemanticsDivergence``: a test that
-    asserts the **bridge's** answer (rather than production's) gets a
-    green light, even though shipping the same code to a real
-    deployment would behave differently.
+    The inverse shape of ``CrossPoolAtomicSemanticsDivergence``: a
+    test that asserts the **bridge's** answer (rather than the
+    deployed-app answer) is GREEN under ``AsyncioRollbackTestCase``,
+    even though identical code shipped to a real deployment of
+    django-async-backend would observe the opposite outcome.
 
-    Concretely: outer ``async_atomic`` wraps an inner sync atomic
-    insert via ``sync_to_async``, then the outer block raises.
+    Same scenario as the previous test — outer ``async_atomic``
+    wrapping an inner sync ``transaction.atomic`` insert via
+    ``sync_to_async``, with the outer block raising — but the
+    assertion encodes ``count == 0`` (what the bridge reports)
+    instead of ``count == 1`` (what a real deployment reports).
 
-    - Under the bridge: both atomics share one psycopg conn; the
-      outer ROLLBACK reverts the inner write. ``count == 0``.
-    - In production: async and sync are separate physical
-      connections; the inner sync atomic committed its savepoint
-      before the outer raised. ``count == 1``.
+    A test author who has never read the bridge's implementation
+    notes can reasonably look at this code, run it under
+    ``AsyncioRollbackTestCase``, see ``row[0] == 0``, codify that as
+    the expected behaviour, and watch CI go green. The same code in
+    production, however, has the inner sync atomic on a separate
+    physical connection — committing the row before the outer
+    rollback runs — so the production observation is ``row[0] == 1``.
 
-    A test author who didn't know about the bridge could write
-    ``assertEqual(count, 0)`` here, watch CI go green, and ship a
-    code path that silently leaks rows in production. That's the
-    structural risk Arfey flagged: the bridge isn't just "covers
-    fewer scenarios", it actively models a different semantics.
+    The framework cannot tell apart these two intents:
 
-    The framework doesn't know which answer the test author meant —
-    it can't tell apart "I'm testing rollback covers everything"
-    from "I'm testing cross-pool isolation". So this passing-but-wrong
-    case has to be addressed at the framework contract level, not by
-    individual test authors being careful.
+      * "I'm testing that my application correctly relies on
+        ``async_atomic`` rolling back work that happened underneath
+        it." (bridge gives the right answer if everything underneath
+        was async)
+      * "I'm testing that my application correctly handles cross-pool
+        isolation, where sync writes persist past async rollbacks."
+        (bridge gives the wrong answer; deployed app behaviour is
+        opposite)
+
+    Both are legitimate uses of an integration test. The bridge's
+    implementation silently picks the first interpretation —
+    everything looks rolled-back because everything ran on one
+    connection — and that interpretation can be wrong without any
+    visible signal at test-write time.
+
+    This test is the artifact of that ambiguity: green CI on a code
+    path whose deployed behaviour the framework hasn't actually
+    verified. Worth deciding at the framework-contract level whether
+    to (a) detect mixed-style atomics on a single proxied connection
+    and raise, (b) ship a companion test base that uses real async +
+    sync connections for code paths whose semantics depend on the
+    two-pool distinction, or (c) document the constraint and rely on
+    adopters to never mix the styles.
     """
 
     async def test_bridge_says_inner_sync_write_was_rolled_back(self):
@@ -320,10 +384,11 @@ class BridgeFlattersDoesNotMatchProduction(AsyncioRollbackTestCase):
                 "WHERE name = 'flatter-demo'"
             )
             row = await c.fetchone()
-            # Asserts the **bridge**'s answer. This is GREEN under
-            # AsyncioRollbackTestCase. Same code shipped to prod would
-            # observe ``row[0] == 1`` because the inner sync atomic
-            # commits independently on the sync connection.
+            # Asserts the **bridge**'s answer. Currently green under
+            # AsyncioRollbackTestCase. The same code shipped to a real
+            # deployment of django-async-backend would observe
+            # ``row[0] == 1`` because the inner sync atomic commits
+            # independently on the sync connection.
             self.assertEqual(row[0], 0)
 
 


### PR DESCRIPTION
**Draft Proof of Concept**

Claude was heavily used in generating this. I'm submitting this as a quick way to see if you like the direction.

## Description

Plain `django.test.TestCase` rolls back writes done via Django's sync connection but not those done via `async_connections`, since the two pools open separate psycopg connections with separate transactions. This blocks adopting `async_connections` in projects that rely on TestCase rollback for test isolation.

`AsyncioRollbackTestCase` (subclass of `django.test.TestCase`) routes every `async_connections[alias]` operation through the Django sync wrapper TestCase opened its transaction on. Implementation:

  - `SyncBridgedAsyncWrapper` mimics `AsyncDatabaseWrapper`. Cursor and savepoint methods dispatch to the captured sync connection via `sync_to_async`. Async-side state attributes (`in_atomic_block`, `savepoint_ids`, ...) live on the proxy; PostgreSQL is the source of truth for the savepoint stack.

  - `async_atomic` works unchanged: with autocommit=False on the sync conn (TestCase's outer transaction), it takes the existing "already in a transaction at the connection level" branch and nests savepoints. Sync and async savepoint-name prefixes can't collide (different thread idents; the bridge also adds an `as_` prefix as belt-and-suspenders).

  - `setUpClass` calls `inc_thread_sharing` on the sync wrapper so the asgiref worker thread can use it. `_run_async_test` swaps `connections._connections` for a `SimpleNamespace` so any `sync_to_async`'d sync ORM call also lands on the captured wrapper instead of opening a fresh autocommit connection on the worker thread.

### Trade-offs (intentional, documented in `sync_bridge.py`):

  - All async I/O serializes through asgiref's single-thread executor. Fine for tests; would be wrong in production code.
  - Test methods only — async setUp/tearDown via `asyncSetUp` / `asyncTearDown` hooks are supported when paired with an `async def` test method.

Tests in `tests/test_rollback_testcase.py` cover: the leak gap with plain TestCase, rollback covering async writes, no cross-test leakage, sync ORM + async raw SQL sharing one transaction, async_atomic savepoint commit/rollback, and `setUpTestData` visibility from the async side.

## Summary by Sourcery

Add a rollback-aware async test case that routes async database operations through Django’s sync test transaction to keep sync and async writes isolated per test.

New Features:
- Introduce AsyncioRollbackTestCase to ensure async database writes participate in Django TestCase transaction rollbacks.
- Provide a SyncBridgedAsyncWrapper that proxies async database access through the underlying sync connection while preserving async transaction state.

Tests:
- Add regression tests verifying that standard TestCase leaks async writes, while AsyncioRollbackTestCase rolls back async operations, shares transactions between sync and async code, preserves async_atomic savepoint semantics, and exposes setUpTestData to async reads.