### PR TITLE
fix: close pool connections acquired in gather child tasks (#24)

### DIFF
--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from django.utils.decorators import async_only_middleware
 
 from django_async_backend.db import async_connections
@@ -17,12 +15,15 @@ def close_async_connections(get_response):
             "django_async_backend.middleware.close_async_connections",
             ...
         ]
+
+    The same cleanup_scope() pattern can be used as a baseline for
+    non-HTTP entry points (background workers, scripts, management
+    commands) -- wrap the unit of work in
+    `async with async_connections.cleanup_scope(): ...`.
     """
 
     async def middleware(request):
-        try:
+        async with async_connections.cleanup_scope():
             return await get_response(request)
-        finally:
-            await asyncio.shield(async_connections.close_all())
 
     return middleware

--- a/django_async_backend/utils/connection.py
+++ b/django_async_backend/utils/connection.py
@@ -1,15 +1,97 @@
 import asyncio
+import contextvars
+import logging
 from contextlib import asynccontextmanager
 
 from django.utils.connection import BaseConnectionHandler
 
+logger = logging.getLogger("django_async_backend")
+
+# Per-scope registry of every wrapper created inside the scope.
+#
+# Because contextvars copy *values* across task boundaries but the list is
+# a mutable object, every asyncio.gather/create_task/TaskGroup child task
+# inherits a reference to the same list. Wrappers appended by children
+# are therefore visible to the task that opened the scope, even though
+# the children's own contextvar dicts (per-task storage) are not.
+#
+# This is what lets a request-scoped cleanup hook reach connections
+# acquired in gather-spawned child tasks.
+_scope_wrappers: contextvars.ContextVar = contextvars.ContextVar(
+    "django_async_backend.scope_wrappers", default=None
+)
+
 
 class BaseAsyncConnectionHandler(BaseConnectionHandler):
+
+    def __getitem__(self, alias):
+        # Reimplemented from BaseConnectionHandler so newly-created wrappers
+        # can be registered into the active cleanup scope. Cached lookups
+        # skip registration (already registered when first created).
+        try:
+            return getattr(self._connections, alias)
+        except AttributeError:
+            if alias not in self.settings:
+                raise self.exception_class(
+                    f"The connection '{alias}' doesn't exist."
+                )
+        conn = self.create_connection(alias)
+        setattr(self._connections, alias, conn)
+        scope = _scope_wrappers.get()
+        if scope is not None:
+            scope.append(conn)
+        return conn
 
     async def close_all(self):
         await asyncio.gather(
             *[conn.close() for conn in self.all(initialized_only=True)]
         )
+
+    @asynccontextmanager
+    async def cleanup_scope(self):
+        """Track wrappers created inside this block and close on exit.
+
+        Use this at the boundary of any unit of work that owns its DB
+        connections (HTTP request, background task, script entry point).
+        Connections acquired in asyncio.gather / create_task / TaskGroup
+        children are reachable from the scope's owning task and will be
+        returned to the pool when the block exits.
+
+        Limitation: an asyncio.create_task() that is not awaited inside
+        the scope continues running with a reference to the scope's
+        list. If it acquires a connection after the scope has begun
+        teardown, that connection is not closed by this scope. Always
+        await spawned tasks before exiting the scope (or wrap them in
+        their own scope).
+        """
+        wrappers = []
+        token = _scope_wrappers.set(wrappers)
+        try:
+            yield
+        finally:
+            _scope_wrappers.reset(token)
+            if wrappers:
+                # wrapper.close() is idempotent (no-ops when no
+                # connection was acquired) so call it unconditionally.
+                # Errors are logged, not re-raised, so one failed close
+                # does not strand the rest. The shield ensures cleanup
+                # completes even if the scope-owning task is cancelled
+                # mid-exit (e.g. a cancelled HTTP request) -- otherwise
+                # the cancellation would propagate into the gather and
+                # leave some connections checked out.
+                results = await asyncio.shield(
+                    asyncio.gather(
+                        *[w.close() for w in wrappers],
+                        return_exceptions=True,
+                    )
+                )
+                for w, result in zip(wrappers, results):
+                    if isinstance(result, BaseException):
+                        logger.exception(
+                            "error closing connection '%s' on scope exit",
+                            getattr(w, "alias", "?"),
+                            exc_info=result,
+                        )
 
     @asynccontextmanager
     async def _independent_connection(self):

--- a/tests/utils/test_connection.py
+++ b/tests/utils/test_connection.py
@@ -244,3 +244,114 @@ class BaseAsyncConnectionHandlerTest(SimpleTestCase):
             origin_connections_map["second"],
             separate_connections_map["second"],
         )
+
+    async def test_cleanup_scope_closes_wrapper_from_scope_task(self):
+        """A wrapper created in the scope's owning task is closed on exit."""
+        async with self.handler.cleanup_scope():
+            conn = self.handler["first"]
+            conn.close.assert_not_called()
+        conn.close.assert_called_once_with()
+
+    async def test_cleanup_scope_closes_gather_child_wrapper(self):
+        """Regression: asyncio.gather child's wrapper is closed on scope exit.
+
+        Before the fix, every gather-spawned child task that created a wrapper
+        leaked it: the wrapper was stored in the child's contextvar context
+        (invisible to the parent task) and never closed when the child task
+        ended. cleanup_scope() makes the wrapper reachable via a mutable list
+        held in a ContextVar that children inherit by reference.
+        """
+        child_connections = []
+
+        async def child():
+            child_connections.append(self.handler["first"])
+
+        async with self.handler.cleanup_scope():
+            await asyncio.gather(child(), child(), child())
+
+        self.assertEqual(len(child_connections), 3)
+        for conn in child_connections:
+            conn.close.assert_called_once_with()
+
+    async def test_cleanup_scope_closes_create_task_child_wrapper(self):
+        """asyncio.create_task children also get cleaned up."""
+        child_connections = []
+
+        async def child():
+            child_connections.append(self.handler["first"])
+
+        async with self.handler.cleanup_scope():
+            await asyncio.create_task(child())
+
+        self.assertEqual(len(child_connections), 1)
+        child_connections[0].close.assert_called_once_with()
+
+    async def test_cleanup_scope_no_effect_outside(self):
+        """Wrappers created outside any scope are not auto-closed."""
+        conn = self.handler["first"]
+        async with self.handler.cleanup_scope():
+            pass
+        conn.close.assert_not_called()
+
+    async def test_cleanup_scope_nested(self):
+        """Nested scopes each close only the wrappers created inside them."""
+        async with self.handler.cleanup_scope():
+            outer = self.handler["first"]
+            async with self.handler.cleanup_scope():
+                inner = self.handler["second"]
+            # Inner scope closed only its own wrapper.
+            inner.close.assert_called_once_with()
+            outer.close.assert_not_called()
+        outer.close.assert_called_once_with()
+
+    async def test_cleanup_scope_closes_on_exception(self):
+        """An exception in the scope body still triggers cleanup."""
+        conn_holder = []
+
+        with self.assertRaises(RuntimeError):
+            async with self.handler.cleanup_scope():
+                conn_holder.append(self.handler["first"])
+                raise RuntimeError("boom")
+
+        conn_holder[0].close.assert_called_once_with()
+
+    async def test_cleanup_scope_close_error_does_not_strand_others(self):
+        """If one wrapper's close() raises, other wrappers still close."""
+
+        class RaisingConnection:
+            def __init__(self, alias):
+                self.alias = alias
+                self.close = AsyncMock(
+                    side_effect=RuntimeError("close failed")
+                )
+
+        class Handler(BaseAsyncConnectionHandler):
+            def create_connection(self, alias):
+                if alias == "first":
+                    return RaisingConnection(alias)
+                return AsyncConnection(alias)
+
+        handler = Handler(default_settings)
+        async with handler.cleanup_scope():
+            a = handler["first"]
+            b = handler["second"]
+
+        a.close.assert_called_once_with()
+        b.close.assert_called_once_with()
+
+    async def test_cleanup_scope_reaches_nested_gather_child(self):
+        """A wrapper created in a gather child of a gather child is closed."""
+        collected = []
+
+        async def grandchild():
+            collected.append(self.handler["first"])
+
+        async def child():
+            await asyncio.gather(grandchild(), grandchild())
+
+        async with self.handler.cleanup_scope():
+            await asyncio.gather(child(), child())
+
+        self.assertEqual(len(collected), 4)
+        for conn in collected:
+            conn.close.assert_called_once_with()


### PR DESCRIPTION
Fixes #24. Draft because human review in progress.

## Problem

`asyncio.gather`/`create_task`/`TaskGroup` spawn child tasks that each get
their own copy of the contextvar storage backing `async_connections`. A DB
call inside a child creates a new `AsyncDatabaseWrapper` in the child's
contextvar context and acquires a connection from `psycopg`'s
`AsyncConnectionPool`. Nothing returns it: the wrapper is invisible to the
request task (different contextvar context), so `close_async_connections`
middleware never sees it. After `pool.max_size` such gathers, every
subsequent `getconn()` hangs forever.

Empirically reproducible with 1 worker doing `gather(asyncio.sleep, db_call)`
in a loop — hangs at iter `pool.max_size + 1`, regardless of concurrency.

## Fix

A `ContextVar` holding a mutable list. `cleanup_scope()` opens the list at
a boundary; `BaseAsyncConnectionHandler.__getitem__` appends every
newly-created wrapper to the active list. Because `ContextVar`s inherit
*by reference* across task boundaries, every gather/create_task child writes
into the same list the scope-owning task can read at exit. On scope close,
every tracked wrapper is closed — parent's *and* children's — returning all
pool connections.

`close_async_connections` middleware now uses `cleanup_scope` so the HTTP
request boundary covers any task spawned during the request. The scope
shields its own cleanup against cancellation and logs (rather than
re-raises) close failures so one failing close does not strand the rest.
**The middleware reduces to a one-liner that doubles as the recommended
pattern for any non-HTTP unit of work (worker tasks, scripts, management
commands).**

**Parallel DB IO is preserved.** Gather children still each get their own
wrapper and their own pool connection — this fix only changes cleanup, not
the per-task connection model.

## Why not the alternatives?

- **PR #10 (signals) on its own** — verified empirically on Django 6.1.dev
  via real HTTP requests: signals fire correctly in the request task's
  context (`asend` path), but `close_old_async_connections` iterates
  `all(initialized_only=True)`, which only sees the request task's own
  contextvar dict — children's wrappers live in a separate contextvar
  context, so the receiver sees `initialized_count=0` and the pool hangs at
  request `max_size + 1`. Signals alone don't fix the bug. See discussion
  in #24.
- **Pre-create-and-share a wrapper at request start** — partially fixes HTTP
  by forcing children to inherit one parent wrapper, but all gather children
  would share one psycopg connection. That serializes parallel queries (or
  raises *"another operation in progress"*), giving up the parallel-IO
  advantage this library exists for.
- **`task.add_done_callback` in `create_connection`** — works but requires
  heuristics (`atomic_blocks` gate to avoid breaking the test framework,
  weakref `_task` to break a `wrapper.features → wrapper` cycle so refcount
  can release). The scope-list approach has no heuristics and a cleaner API.
- **`weakref.finalize` on the wrapper** — doesn't fire promptly: Django's
  `DatabaseFeatures` keeps the wrapper alive via an internal cycle (refcount
  won't release without a cyclic GC sweep).

## Upstreaming path (when the library drops Django 6.0)

The `cleanup_scope` mechanism here is portable — only the *activation point*
is Django-version-specific. Django 6.1's `ASGIHandler` already `await`s
`request_started.asend()` and `request_finished.asend()` in the request
task's context, so once min Django is 6.1+ the middleware can collapse into
signal handlers connected from `apps.ready()`:

    async def _open_scope(**kw): _scope_wrappers.set([])
    async def _close_scope(**kw):
        for w in _scope_wrappers.get(None) or []:
            await w.close()

**Verified empirically:** with the scope-list mechanism in this PR plus the
two signal handlers above (and no middleware), 8 HTTP requests at
POOL_MAX=4 all succeeded, with `_close_scope` logging
`wrappers_in_scope=1` per request — the gather child's wrapper reachable
from the request task. Without the scope-list mechanism (PR #10 alone), the
same setup hangs at req 5.

So this PR is stage 0 of a clean two-step roadmap. Same `cleanup_scope`
primitive in both stages; only the activation moves from middleware to
signal handler.

## Non-HTTP entry points

Workers, scripts, and management commands have no middleware. They should
wrap their unit of work in `cleanup_scope()` explicitly:

    async def task_body():
        async with async_connections.cleanup_scope():
            await do_work()  # may use asyncio.gather over DB calls

## Testing

- Full upstream test suite: 317 tests, 1 pre-existing unrelated failure
  (`pg version 18 != 15` assertion on postgres 18), 0 new regressions.
- 8 new regression tests in `tests/utils/test_connection.py` covering:
  - wrapper from scope-owning task closed
  - gather child wrapper closed (the bug)
  - create_task child wrapper closed
  - no-op outside scope
  - nested scopes (inner closes only its own)
  - exception in scope body still closes
  - failing close does not strand others
  - nested gather (grandchild) still reaches outer scope
- Standalone repro scripts (single-file, postgres only): pre-fix hang at iter
  `POOL_MAX+1`, post-fix complete cleanly. Happy to upstream the probes if
  useful.
- Real-HTTP verification of the stage-1 upstreaming path: Django 6.1.dev,
  signal handlers wired to the scope-list, no middleware — 8/8 requests at
  POOL_MAX=4 succeed.

## Known limitation

A detached `asyncio.create_task()` that outlives `cleanup_scope` continues
running with a reference to the scope's list. If it acquires a connection
after the scope has begun teardown, that connection is not closed by this
scope. Documented in the `cleanup_scope` docstring — pattern is "await your
tasks inside the scope, or wrap them in their own scope."

## Summary by Sourcery

Track async database connection wrappers within a per-request cleanup scope so connections acquired in child tasks are reliably closed, and update middleware to use this scoped cleanup instead of a global close-all.

Bug Fixes:
- Ensure connections acquired in asyncio.gather/create_task/TaskGroup children are closed at the end of the owning scope, preventing connection pool exhaustion and hangs.

Enhancements:
- Introduce a cleanup_scope context manager on the async connection handler to track and close all wrappers created within a logical unit of work, including nested scopes and error paths.
- Log and continue when closing one connection wrapper fails so other connections in the same scope are still released.
- Customize BaseAsyncConnectionHandler indexing to register newly created wrappers with the active cleanup scope.

Tests:
- Add regression tests covering cleanup_scope behavior across normal execution, exceptions, nested scopes, gather/create_task children, nested gathers, and close failures.
