### PR TITLE
Lock ensure_connection() to prevent gather-child connection race

### DIFF
--- a/django_async_backend/db/backends/base/base.py
+++ b/django_async_backend/db/backends/base/base.py
@@ -1,4 +1,5 @@
 import _thread
+import asyncio
 import copy
 import datetime
 import logging
@@ -100,6 +101,12 @@ class BaseAsyncDatabaseWrapper:
         self._thread_sharing_lock = threading.Lock()
         self._thread_sharing_count = 0
         self._thread_ident = _thread.get_ident()
+
+        # Serializes ensure_connection() against itself when multiple
+        # asyncio tasks race on the lazy connection acquisition. The
+        # typical trigger is asyncio.gather children that inherit this
+        # wrapper via contextvar copy-on-write.
+        self._async_connection_lock = asyncio.Lock()
 
         # A list of no-argument functions to run when the transaction commits.
         # Each entry is an (sids, func, robust) tuple, where sids is a set of
@@ -273,14 +280,21 @@ class BaseAsyncDatabaseWrapper:
             )
 
     async def ensure_connection(self):
-        """Guarantee that a connection to the database is established."""
+        """Guarantee that a connection to the database is established.
+
+        Uses double-checked locking so concurrent tasks sharing this
+        wrapper (e.g. asyncio.gather children) don't each acquire their
+        own pool connection while losing the assignment race.
+        """
         if self.connection is None:
-            if self.in_atomic_block and self.closed_in_transaction:
-                raise ProgrammingError(
-                    "Cannot open a new connection in an atomic block."
-                )
-            with self.wrap_database_errors:
-                await self.connect()
+            async with self._async_connection_lock:
+                if self.connection is None:
+                    if self.in_atomic_block and self.closed_in_transaction:
+                        raise ProgrammingError(
+                            "Cannot open a new connection in an atomic block."
+                        )
+                    with self.wrap_database_errors:
+                        await self.connect()
 
     # ##### Backend-specific wrappers for PEP-249 connection methods #####
 

--- a/tests/db/backends/base/test_base.py
+++ b/tests/db/backends/base/test_base.py
@@ -1,3 +1,4 @@
+import asyncio
 import gc
 from unittest import skipIf
 from unittest.mock import (
@@ -114,6 +115,42 @@ class DatabaseWrapperTests(AsyncioTransactionTestCase):
             connection.features, "minimum_database_version", None
         ):
             await connection.check_database_version_supported()
+
+    async def test_ensure_connection_no_race_under_concurrent_tasks(self):
+        """Concurrent tasks sharing one wrapper must not each acquire
+        a separate connection. Without serialization in ensure_connection
+        the gather children all observe `self.connection is None`,
+        all call connect(), and only the last assignment to
+        self.connection survives — the others orphan from the pool."""
+        wrapper = async_connections[DEFAULT_DB_ALIAS]
+        # Force the slow path: connection back to None.
+        await wrapper.close()
+        self.assertIsNone(wrapper.connection)
+
+        call_count = 0
+        original_connect = wrapper.connect
+
+        async def counting_connect():
+            nonlocal call_count
+            call_count += 1
+            # Yield so the other gather children waiting on the lock
+            # would otherwise reach the same `is None` check.
+            await asyncio.sleep(0)
+            await original_connect()
+
+        with patch.object(wrapper, "connect", counting_connect):
+            await asyncio.gather(
+                *[wrapper.ensure_connection() for _ in range(4)]
+            )
+
+        self.assertEqual(
+            call_count,
+            1,
+            "Expected ensure_connection() to call connect() exactly once "
+            "across 4 concurrent tasks; got %d. The double-checked lock "
+            "in ensure_connection() is missing or broken." % call_count,
+        )
+        self.assertIsNotNone(wrapper.connection)
 
     @skipIf(django.VERSION < (6, 0), "Requires Django 6.0 or higher")
     async def test_release_memory_without_garbage_collection(self):


### PR DESCRIPTION
Related to #24 — orthogonal to the `all()` fix; can land either way.

## Problem

`ensure_connection()` has a classic check-then-act race across asyncio tasks
that share an `AsyncDatabaseWrapper`:

```python
async def ensure_connection(self):
    if self.connection is None:                # check
        ...
        await self.connect()                   # acts after awaiting
```

When `asyncio.gather` children inherit one wrapper via contextvar
copy-on-write, they all observe `self.connection is None`, all enter
`connect()`, all `await self.get_new_connection()`. Each acquires its own
pool connection. The assignments `self.connection = my_conn` then race;
only the last writer survives. The other N-1 connections are referenced
only by their pending cursors and orphan when the cursors close — no
`putconn()` ever happens.

Visible as: pool `size` grows past what the workload should need, and
`pool_size - pool_available` after the request boundary cleanup equals
`gather_children - 1`.

## Fix

`asyncio.Lock` on the wrapper + double-checked locking in
`ensure_connection()`. Fast path (connection already set) skips the lock
entirely; concurrent first-time acquisitions queue, the winner calls
`connect()`, the losers re-check inside the lock and return.

```python
async def ensure_connection(self):
    if self.connection is None:
        async with self._async_connection_lock:
            if self.connection is None:
                ...
                await self.connect()
```

5 lines of logic + one new attribute. No API change. Preserves the
intended "share the wrapper" semantics — gather children still share one
psycopg connection and serialize through it.

## Relationship to the `all()` fix

Independent. The `all()` fix addresses the "wrappers aren't discoverable
from the request task" half of #24; this fix addresses the "racing
children each grab their own connection from the pool" half. They
compose: with both, signal-based cleanup reaches the shared wrapper, and
the shared wrapper actually holds exactly one connection. Either can
land first.

## Summary by Sourcery

Serialize asynchronous database connection establishment to avoid concurrent tasks racing when lazily acquiring a shared connection.

Enhancements:
- Add an asyncio-based lock and double-checked locking around async connection initialization to prevent multiple pool connections being created for a single shared wrapper.

Tests:
- Add a concurrency test that verifies ensure_connection() only invokes connect() once across multiple asyncio.gather children sharing the same wrapper.