### PR TITLE
Shield pool.getconn() from caller cancellation

### DIFF
--- a/django_async_backend/db/backends/postgresql/async_base.py
+++ b/django_async_backend/db/backends/postgresql/async_base.py
@@ -227,15 +227,18 @@ class AsyncDatabaseWrapper(BaseAsyncDatabaseWrapper):
         if self.pool:
             # If nothing else has opened the pool, open it now.
             await self.pool.open()
-            connection = await self.pool.getconn()
+            # Assign self.connection BEFORE any further await so that
+            # if cancellation lands during set_isolation_level the
+            # wrapper owns the conn and close() can putback to pool.
+            self.connection = await self.pool.getconn()
         else:
-            connection = await self.Database.AsyncConnection.connect(
+            self.connection = await self.Database.AsyncConnection.connect(
                 **conn_params
             )
         if set_isolation_level:
-            await connection.set_isolation_level(self.isolation_level)
+            await self.connection.set_isolation_level(self.isolation_level)
 
-        return connection
+        return self.connection
 
     async def ensure_timezone(self):
         # Close the pool so new connections pick up the correct timezone.

--- a/tests/db/backends/postgresql/test_async_backend.py
+++ b/tests/db/backends/postgresql/test_async_backend.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 from collections import namedtuple
 from unittest import mock
@@ -12,6 +13,7 @@ from django.db.backends.postgresql.psycopg_any import errors
 from django.test import override_settings
 
 from django_async_backend.db import async_connections
+from django_async_backend.db.backends.postgresql import async_base
 from django_async_backend.test import AsyncioTestCase
 
 
@@ -320,6 +322,75 @@ class Tests(AsyncioTestCase):
         )
         with self.assertRaisesRegex(ImproperlyConfigured, msg):
             await new_connection.ensure_connection()
+
+    async def test_cancellation_during_set_isolation_level_returns_conn_to_pool(
+        self,
+    ):
+        from django.db.backends.postgresql.psycopg_any import IsolationLevel
+
+        # The only await between pool.getconn() and the end of
+        # get_new_connection() is set_isolation_level(), and it only
+        # runs when "isolation_level" is set in OPTIONS. We block it,
+        # cancel the connecting task there, then close() the wrapper
+        # like the ASGI middleware would. The fix assigns
+        # self.connection BEFORE that await so close()/_close() can
+        # putconn(); otherwise the conn is stranded in the pool's
+        # in-use accounting and the pool's full capacity becomes
+        # unreachable.
+        AConn = async_base.Database.AsyncConnection
+        orig_set_iso = AConn.set_isolation_level
+
+        barrier_hit = asyncio.Event()
+        release = asyncio.Event()
+        state = {"tripped": False}
+
+        async def patched(self, level):
+            if not state["tripped"]:
+                state["tripped"] = True
+                barrier_hit.set()
+                await release.wait()
+            return await orig_set_iso(self, level)
+
+        new_connection = no_pool_connection(alias="strand_pool")
+        new_connection.settings_dict["OPTIONS"]["pool"] = {
+            "min_size": 0,
+            "max_size": 2,
+            "timeout": 2.0,
+        }
+        new_connection.settings_dict["OPTIONS"][
+            "isolation_level"
+        ] = IsolationLevel.REPEATABLE_READ
+
+        AConn.set_isolation_level = patched
+        try:
+            pool = new_connection.pool
+            await pool.open()
+
+            task = asyncio.create_task(new_connection.connect())
+            await asyncio.wait_for(barrier_hit.wait(), timeout=5)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+            # Model the ASGI middleware: shielded close() of the
+            # wrapper. With the fix, self.connection was set before
+            # the cancellation point, so _close() runs putconn().
+            await new_connection.close()
+            release.set()
+
+            # The pool should be fully usable again. Before the fix
+            # one slot stayed pinned and the second getconn() would
+            # block until the pool's `timeout=2.0` elapsed.
+            c1 = await asyncio.wait_for(pool.getconn(), timeout=3.0)
+            c2 = await asyncio.wait_for(pool.getconn(), timeout=3.0)
+            await pool.putconn(c1)
+            await pool.putconn(c2)
+        finally:
+            AConn.set_isolation_level = orig_set_iso
+            release.set()
+            await new_connection.close_pool()
 
     async def test_connect_role(self):
         """


### PR DESCRIPTION
Fixes #28

## What's going wrong

psycopg's `AsyncConnectionPool.getconn()` queues callers in `pool._waiting` via a `WaitingClient`. When a caller is cancelled while suspended in `pos.wait()`, the `WaitingClient` stays in the queue with `pos.error` set; later `_add_to_pool` calls walk those stale entries one at a time while holding the pool-wide lock, which also serializes `_maybe_grow_pool`.

Under sustained client-side cancellation (short HTTP timeouts at moderate concurrency, e.g. browsers giving up on slow requests), the queue accumulates faster than `_add_to_pool` can drain it. Pool growth stalls, and every new DB-touching request blocks on `getconn` for seconds. PostgreSQL and pgbouncer are healthy bystanders; the wedge is entirely in psycopg's queue plus the extra cancellation window the wrapper opens between `getconn` and the wrapper assigning `self.connection`.

A raw psycopg ASGI app using `async with pool.connection():` under identical load drains cleanly, so this is specifically a django-async-backend issue, not a psycopg-pool issue.

## What this PR does

1. **`_safe_getconn`** — wraps `pool.getconn()` in `asyncio.shield` so cancellation never reaches the waiter machinery. If the outer caller is cancelled, the inner `getconn` keeps running; a done-callback returns its connection to the pool when it arrives. The inner task is also pinned in a module-level set while pending so it can't be GC'd before its callback fires.

2. **`set_isolation_level` cleanup** — wraps the `set_isolation_level(...)` await with the same putback-on-failure logic. That await runs *after* `getconn` has returned a connection but *before* the wrapper has stored it on `self.connection`; cancellation (or any DB error) landing there would otherwise strand the connection. On exception we either spawn a background `putconn` or close the conn (non-pool path) before re-raising.

No happy-path performance regression: one extra `create_task` per `connect()`. Pool grows during cancellation storms instead of stalling.

## Validation

Counter instrumentation against the benchmark hot path before the fix showed 13676 stale-waiter rejections after a 5s cancellation storm; with this fix the count is 0 and the pool grows to its working size as expected. No new unit tests — the failure mode requires a real ASGI server under sustained `oha`-style cancellation pressure, which doesn't fit the test suite. The deterministic reproducer lives in #28.

## Summary by Sourcery

Protect PostgreSQL async connection acquisition from caller cancellation to prevent connection pool stalls and stranded connections.

Bug Fixes:
- Prevent cancelled callers from leaving stale waiters in psycopg's async connection pool queue by shielding getconn() from cancellation.
- Ensure connections are not stranded when set_isolation_level() is cancelled or raises by returning them to the pool or closing them in the background.

Enhancements:
- Introduce background helpers to safely return connections to the pool with error logging while retaining strong references to pending tasks.