### PR TITLE
Fix/middleware close all aliases

### DIFF
--- a/django_async_backend/db/__init__.py
+++ b/django_async_backend/db/__init__.py
@@ -1,3 +1,12 @@
 from django_async_backend.db.utils import AsyncConnectionHandler
 
 async_connections = AsyncConnectionHandler()
+
+
+async def close_old_async_connections(**kwargs):
+    # all() (not initialized_only=True) so we still close aliases that
+    # were initialized in a gather child's contextvar copy and may not
+    # appear in the request task's initialized list. close() is a no-op
+    # when the wrapper has no underlying connection.
+    for conn in async_connections.all():
+        await conn.close()

--- a/django_async_backend/db/__init__.py
+++ b/django_async_backend/db/__init__.py
@@ -4,11 +4,9 @@ async_connections = AsyncConnectionHandler()
 
 
 async def close_old_async_connections(**kwargs):
-    # all() — not initialized_only=True — so close() runs for every
-    # configured alias regardless of whether this task touched it yet.
-    # Matches PR #10's signal-handler shape so the same function works
-    # both as middleware cleanup and as a request_started /
-    # request_finished signal handler. close() is a no-op on a wrapper
-    # with no underlying connection, so the extra aliases are free.
+    # Close every configured connection alias. close() is a no-op on a
+    # wrapper with no underlying connection, so walking aliases this
+    # task hasn't touched is free. **kwargs lets the same function be
+    # connected as a request_started / request_finished signal handler.
     for conn in async_connections.all():
         await conn.close()

--- a/django_async_backend/db/__init__.py
+++ b/django_async_backend/db/__init__.py
@@ -4,9 +4,11 @@ async_connections = AsyncConnectionHandler()
 
 
 async def close_old_async_connections(**kwargs):
-    # all() (not initialized_only=True) so we still close aliases that
-    # were initialized in a gather child's contextvar copy and may not
-    # appear in the request task's initialized list. close() is a no-op
-    # when the wrapper has no underlying connection.
+    # all() — not initialized_only=True — so close() runs for every
+    # configured alias regardless of whether this task touched it yet.
+    # Matches PR #10's signal-handler shape so the same function works
+    # both as middleware cleanup and as a request_started /
+    # request_finished signal handler. close() is a no-op on a wrapper
+    # with no underlying connection, so the extra aliases are free.
     for conn in async_connections.all():
         await conn.close()

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -20,6 +20,12 @@ def close_async_connections(get_response):
     """
 
     async def middleware(request):
+        # Per issue #24: walking async_connections.all() (not
+        # initialized_only=True) ensures wrappers created in gather-child
+        # task contexts get a parent-visible close(). close() is a no-op
+        # when there's no underlying connection, so in the healthy case
+        # the pre-request call costs nothing — it exists to mop up state
+        # that survived a prior request on the same worker thread.
         await close_old_async_connections()
         try:
             return await get_response(request)

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -20,6 +20,7 @@ def close_async_connections(get_response):
     """
 
     async def middleware(request):
+        await close_old_async_connections()
         try:
             return await get_response(request)
         finally:

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -2,7 +2,7 @@ import asyncio
 
 from django.utils.decorators import async_only_middleware
 
-from django_async_backend.db import async_connections
+from django_async_backend.db import close_old_async_connections
 
 
 @async_only_middleware
@@ -23,6 +23,6 @@ def close_async_connections(get_response):
         try:
             return await get_response(request)
         finally:
-            await asyncio.shield(async_connections.close_all())
+            await asyncio.shield(close_old_async_connections())
 
     return middleware

--- a/django_async_backend/middleware.py
+++ b/django_async_backend/middleware.py
@@ -20,12 +20,12 @@ def close_async_connections(get_response):
     """
 
     async def middleware(request):
-        # Per issue #24: walking async_connections.all() (not
-        # initialized_only=True) ensures wrappers created in gather-child
-        # task contexts get a parent-visible close(). close() is a no-op
-        # when there's no underlying connection, so in the healthy case
-        # the pre-request call costs nothing — it exists to mop up state
-        # that survived a prior request on the same worker thread.
+        # Defensive cleanup before the request runs. Connection wrappers
+        # are thread-local — shared across tasks on the same worker
+        # thread — so a prior request's state can persist if its
+        # post-cleanup didn't fully complete. close() is a no-op when
+        # there's no underlying connection, so this is free in the
+        # healthy case.
         await close_old_async_connections()
         try:
             return await get_response(request)

--- a/tests/db/test_close_old_async_connections.py
+++ b/tests/db/test_close_old_async_connections.py
@@ -1,0 +1,39 @@
+from unittest.mock import AsyncMock, patch
+
+from django.test import SimpleTestCase
+
+from django_async_backend.db import (
+    async_connections,
+    close_old_async_connections,
+)
+
+
+class CloseOldAsyncConnectionsTest(SimpleTestCase):
+    async def test_closes_every_configured_alias_even_when_uninitialized(self):
+        """`all()` (not initialized_only=True) is required so wrappers
+        created inside an asyncio.gather child's contextvar copy still get
+        their close() invoked — those wrappers don't appear in the parent
+        task's initialized list."""
+        first = AsyncMock()
+        first.alias = "first"
+        second = AsyncMock()
+        second.alias = "second"
+
+        with patch.object(
+            async_connections, "all", return_value=[first, second]
+        ) as mocked_all:
+            await close_old_async_connections()
+
+        mocked_all.assert_called_once_with()
+        _, kwargs = mocked_all.call_args
+        self.assertNotIn("initialized_only", kwargs)
+        first.close.assert_awaited_once_with()
+        second.close.assert_awaited_once_with()
+
+    async def test_accepts_signal_kwargs(self):
+        """Connected as a request_started/request_finished signal handler
+        in some deployments — must accept arbitrary kwargs."""
+        with patch.object(async_connections, "all", return_value=[]):
+            await close_old_async_connections(
+                sender=object(), signal=object(), environ={}
+            )

--- a/tests/db/test_close_old_async_connections.py
+++ b/tests/db/test_close_old_async_connections.py
@@ -9,11 +9,10 @@ from django_async_backend.db import (
 
 
 class CloseOldAsyncConnectionsTest(SimpleTestCase):
-    async def test_closes_every_configured_alias_even_when_uninitialized(self):
-        """`all()` (not initialized_only=True) is required so wrappers
-        created inside an asyncio.gather child's contextvar copy still get
-        their close() invoked — those wrappers don't appear in the parent
-        task's initialized list."""
+    async def test_iterates_all_aliases_not_initialized_only(self):
+        """Walks every configured alias, not initialized_only=True.
+        Lets the same function serve as middleware cleanup and as a
+        request_started/request_finished signal handler (PR #10)."""
         first = AsyncMock()
         first.alias = "first"
         second = AsyncMock()

--- a/tests/db/test_close_old_async_connections.py
+++ b/tests/db/test_close_old_async_connections.py
@@ -9,10 +9,7 @@ from django_async_backend.db import (
 
 
 class CloseOldAsyncConnectionsTest(SimpleTestCase):
-    async def test_iterates_all_aliases_not_initialized_only(self):
-        """Walks every configured alias, not initialized_only=True.
-        Lets the same function serve as middleware cleanup and as a
-        request_started/request_finished signal handler (PR #10)."""
+    async def test_closes_every_configured_alias(self):
         first = AsyncMock()
         first.alias = "first"
         second = AsyncMock()
@@ -24,8 +21,6 @@ class CloseOldAsyncConnectionsTest(SimpleTestCase):
             await close_old_async_connections()
 
         mocked_all.assert_called_once_with()
-        _, kwargs = mocked_all.call_args
-        self.assertNotIn("initialized_only", kwargs)
         first.close.assert_awaited_once_with()
         second.close.assert_awaited_once_with()
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -7,19 +7,28 @@ from django_async_backend.middleware import close_async_connections
 
 
 class CloseAsyncConnectionsMiddlewareTest(SimpleTestCase):
-    async def test_closes_connections_after_response(self):
-        get_response = AsyncMock(return_value="response")
+    async def test_closes_connections_before_and_after_response(self):
+        """Mirrors the request_started + request_finished signal pair so
+        the request runs against a freshly empty connection set and any
+        stragglers it leaves behind get returned to the pool."""
+        order = []
+        get_response = AsyncMock(
+            side_effect=lambda req: order.append("response") or "response"
+        )
         middleware = close_async_connections(get_response)
+
+        async def tracking_close(**kwargs):
+            order.append("close")
 
         with patch(
             "django_async_backend.middleware.close_old_async_connections",
-            new=AsyncMock(),
-        ) as mocked_close:
+            new=tracking_close,
+        ):
             result = await middleware("request")
 
         self.assertEqual(result, "response")
         get_response.assert_awaited_once_with("request")
-        mocked_close.assert_awaited_once_with()
+        self.assertEqual(order, ["close", "response", "close"])
 
     async def test_closes_connections_when_get_response_raises(self):
         get_response = AsyncMock(side_effect=RuntimeError("boom"))
@@ -32,19 +41,26 @@ class CloseAsyncConnectionsMiddlewareTest(SimpleTestCase):
             with self.assertRaisesMessage(RuntimeError, "boom"):
                 await middleware("request")
 
-        mocked_close.assert_awaited_once_with()
+        # Once before get_response, once in the finally after it raised.
+        self.assertEqual(mocked_close.await_count, 2)
 
     async def test_close_is_shielded_from_cancellation(self):
-        """If the outer task is cancelled mid-response, the cleanup must
-        still run to completion so pool connections don't strand."""
-        cleanup_finished = False
+        """If the outer task is cancelled mid-response, the post-response
+        cleanup must still run to completion so pool connections don't
+        strand. Pre-response close is intentionally NOT shielded — a
+        cancellation that early just aborts the request."""
+        post_response_cleanup_count = 0
+        in_response = asyncio.Event()
 
-        async def slow_close(**kwargs):
-            nonlocal cleanup_finished
-            await asyncio.sleep(0.05)
-            cleanup_finished = True
+        async def close(**kwargs):
+            if in_response.is_set():
+                # Running from the finally — must complete despite cancel.
+                await asyncio.sleep(0.05)
+                nonlocal post_response_cleanup_count
+                post_response_cleanup_count += 1
 
         async def slow_response(_request):
+            in_response.set()
             await asyncio.sleep(0.05)
             return "response"
 
@@ -52,16 +68,19 @@ class CloseAsyncConnectionsMiddlewareTest(SimpleTestCase):
 
         with patch(
             "django_async_backend.middleware.close_old_async_connections",
-            new=slow_close,
+            new=close,
         ):
             task = asyncio.create_task(middleware("request"))
-            await asyncio.sleep(0.01)
+            await in_response.wait()
             task.cancel()
             with self.assertRaises(asyncio.CancelledError):
                 await task
+            # Give the shielded background coroutine a chance to finish.
+            await asyncio.sleep(0.1)
 
-        self.assertTrue(
-            cleanup_finished,
+        self.assertEqual(
+            post_response_cleanup_count,
+            1,
             "close_old_async_connections must finish even when the request "
             "task is cancelled (asyncio.shield).",
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -12,13 +12,15 @@ class CloseAsyncConnectionsMiddlewareTest(SimpleTestCase):
         the request runs against a freshly empty connection set and any
         stragglers it leaves behind get returned to the pool."""
         order = []
-        get_response = AsyncMock(
-            side_effect=lambda req: order.append("response") or "response"
-        )
-        middleware = close_async_connections(get_response)
+
+        async def get_response(_request):
+            order.append("response")
+            return "response"
 
         async def tracking_close(**kwargs):
             order.append("close")
+
+        middleware = close_async_connections(get_response)
 
         with patch(
             "django_async_backend.middleware.close_old_async_connections",
@@ -27,41 +29,50 @@ class CloseAsyncConnectionsMiddlewareTest(SimpleTestCase):
             result = await middleware("request")
 
         self.assertEqual(result, "response")
-        get_response.assert_awaited_once_with("request")
         self.assertEqual(order, ["close", "response", "close"])
 
     async def test_closes_connections_when_get_response_raises(self):
-        get_response = AsyncMock(side_effect=RuntimeError("boom"))
+        order = []
+
+        async def get_response(_request):
+            order.append("response")
+            raise RuntimeError("boom")
+
+        async def tracking_close(**kwargs):
+            order.append("close")
+
         middleware = close_async_connections(get_response)
 
         with patch(
             "django_async_backend.middleware.close_old_async_connections",
-            new=AsyncMock(),
-        ) as mocked_close:
+            new=tracking_close,
+        ):
             with self.assertRaisesMessage(RuntimeError, "boom"):
                 await middleware("request")
 
-        # Once before get_response, once in the finally after it raised.
-        self.assertEqual(mocked_close.await_count, 2)
+        # Pre-close, response (which raises), then finally-close.
+        self.assertEqual(order, ["close", "response", "close"])
 
     async def test_close_is_shielded_from_cancellation(self):
         """If the outer task is cancelled mid-response, the post-response
         cleanup must still run to completion so pool connections don't
         strand. Pre-response close is intentionally NOT shielded — a
         cancellation that early just aborts the request."""
-        post_response_cleanup_count = 0
         in_response = asyncio.Event()
+        cleanup_done = asyncio.Event()
 
         async def close(**kwargs):
-            if in_response.is_set():
-                # Running from the finally — must complete despite cancel.
-                await asyncio.sleep(0.05)
-                nonlocal post_response_cleanup_count
-                post_response_cleanup_count += 1
+            if not in_response.is_set():
+                # Pre-response close — fast path, nothing to assert.
+                return
+            # Finally close — yield once so the outer task can deliver
+            # the cancellation, then prove we still complete.
+            await asyncio.sleep(0)
+            cleanup_done.set()
 
         async def slow_response(_request):
             in_response.set()
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(1)  # cancelled before this finishes
             return "response"
 
         middleware = close_async_connections(slow_response)
@@ -75,12 +86,10 @@ class CloseAsyncConnectionsMiddlewareTest(SimpleTestCase):
             task.cancel()
             with self.assertRaises(asyncio.CancelledError):
                 await task
-            # Give the shielded background coroutine a chance to finish.
-            await asyncio.sleep(0.1)
+            await asyncio.wait_for(cleanup_done.wait(), timeout=1)
 
-        self.assertEqual(
-            post_response_cleanup_count,
-            1,
+        self.assertTrue(
+            cleanup_done.is_set(),
             "close_old_async_connections must finish even when the request "
             "task is cancelled (asyncio.shield).",
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,67 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from django.test import SimpleTestCase
+
+from django_async_backend.middleware import close_async_connections
+
+
+class CloseAsyncConnectionsMiddlewareTest(SimpleTestCase):
+    async def test_closes_connections_after_response(self):
+        get_response = AsyncMock(return_value="response")
+        middleware = close_async_connections(get_response)
+
+        with patch(
+            "django_async_backend.middleware.close_old_async_connections",
+            new=AsyncMock(),
+        ) as mocked_close:
+            result = await middleware("request")
+
+        self.assertEqual(result, "response")
+        get_response.assert_awaited_once_with("request")
+        mocked_close.assert_awaited_once_with()
+
+    async def test_closes_connections_when_get_response_raises(self):
+        get_response = AsyncMock(side_effect=RuntimeError("boom"))
+        middleware = close_async_connections(get_response)
+
+        with patch(
+            "django_async_backend.middleware.close_old_async_connections",
+            new=AsyncMock(),
+        ) as mocked_close:
+            with self.assertRaisesMessage(RuntimeError, "boom"):
+                await middleware("request")
+
+        mocked_close.assert_awaited_once_with()
+
+    async def test_close_is_shielded_from_cancellation(self):
+        """If the outer task is cancelled mid-response, the cleanup must
+        still run to completion so pool connections don't strand."""
+        cleanup_finished = False
+
+        async def slow_close(**kwargs):
+            nonlocal cleanup_finished
+            await asyncio.sleep(0.05)
+            cleanup_finished = True
+
+        async def slow_response(_request):
+            await asyncio.sleep(0.05)
+            return "response"
+
+        middleware = close_async_connections(slow_response)
+
+        with patch(
+            "django_async_backend.middleware.close_old_async_connections",
+            new=slow_close,
+        ):
+            task = asyncio.create_task(middleware("request"))
+            await asyncio.sleep(0.01)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        self.assertTrue(
+            cleanup_finished,
+            "close_old_async_connections must finish even when the request "
+            "task is cancelled (asyncio.shield).",
+        )


### PR DESCRIPTION
## Summary by Sourcery

Ensure async database connections are fully closed before and after each async request, mirroring Django’s request_started/request_finished semantics for all connection aliases.

Bug Fixes:
- Close all configured async connection aliases instead of only the ones previously touched, preventing stale connections from leaking across requests.
- Guarantee post-response async connection cleanup completes even when the request task is cancelled.

Tests:
- Add middleware tests to verify connections are closed before and after responses, including when the view raises or the request task is cancelled.
- Add db-level tests to confirm close_old_async_connections iterates every alias and accepts arbitrary signal-style kwargs.