### PR TITLE
docs: document concurrency model and code generation (#26)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. The
+[README](./README.md) is the source of truth; this file just calls out the
+things that are easy to get wrong.
+
+## Remember this
+
+- **Async does not mean parallel.** Database queries are not run in parallel by
+  default. All async ORM and cursor calls within an async context share one
+  connection per alias, so concurrent queries — even under `asyncio.gather()` —
+  are serialized on that connection. To run queries in parallel you must opt in
+  explicitly with `async_connections._independent_connection()` (a concept, not
+  production-ready). Do not assume "django-async-backend" parallelizes queries
+  for you. See the README "Concurrency model" and "DEP 0009" sections.
+
+- **Part of the ORM is generated, not hand-written.** Some ORM modules are
+  produced from Django's source by the `codemon` tool and committed to git, so
+  they look hand-written but are not. Each carries a `# This file was generated
+  automatically. Do not modify it manually.` header. Do not hand-edit those
+  files — your changes will be lost on the next regeneration. Edit the config
+  under `codemon/config/*.yaml` and run `lets test_generate` (not a bare
+  `python -m codemon`) instead. See the README "Code generation" section.
+
+- **Generated code is committed.** Because the generated modules are checked in,
+  a diff can look like ordinary handwritten code. If you touch the ORM layer,
+  check whether the file is generated before editing it.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ MIDDLEWARE = [
 
 ---
 
+## Concurrency model
+
+> ⚠️ **Async does not mean parallel here.** Database queries are *not* run in
+> parallel by default.
+
+Within a single async context (such as one request or task), all async ORM and
+cursor calls share **one connection per database alias**. Because they share a
+connection, queries are serialized — running them under `asyncio.gather()` does
+**not** execute them on the database concurrently; they take turns on the shared
+connection.
+
+This is a deliberate design choice that mirrors Django's DEP 0009. To run
+queries truly in parallel, you must opt in explicitly and give each one its own
+connection with `async_connections._independent_connection()`. See the
+[DEP 0009](#dep-0009) section below for details and an example.
+
+---
+
 ## Connection Handler
 
 The connection handler manages database connections for your async backend.
@@ -293,6 +311,31 @@ Not supported ❌
 | `User.objects.acreate_user` | ❌        |          |
 | `...`                       | ❌        |          |
 
+
+## Code generation
+
+Part of the ORM layer is **generated, not hand-written**. The async versions of
+Django's query classes are produced from Django's own source by the `codemon`
+tool (under `codemon/`), which rewrites the sync code into async using libcst.
+
+These files are committed to git (so the package installs without running
+codegen) and track a specific Django version, so they look hand-written but are
+not. Each starts with a `# This file was generated automatically. Do not modify
+it manually.` header.
+
+To change them, edit the codemon config under `codemon/config/*.yaml` — **not**
+the generated files — then regenerate:
+
+```bash
+lets test_generate
+```
+
+This restores the Django-derived files to pristine, runs `python -m codemon`,
+and reformats the result — running `codemon` on its own skips the
+restore/reformat and produces large formatting-only diffs. Regeneration
+downloads Django's source for the pinned version over the network, so it needs
+internet access. Any manual edits to the generated modules will be lost on the
+next regeneration.
 
 ## ⚙️ Development Setup
 


### PR DESCRIPTION
Surface two design facts that LLMs (and humans) commonly get wrong:

- Concurrency model: async DB access shares one connection per alias, so queries are serialized, not parallel, unless you opt into _independent_connection(). Previously only implied in the DEP 0009 section, which buried the lede.
- Code generation: part of the ORM is generated by codemon from Django's source and committed to git, so it looks hand-written but is not.

Add AGENTS.md with the same two points as agent-facing "remember this" callouts; README remains the source of truth.

## Summary by Sourcery

Document the async database concurrency model and the code-generation workflow for the ORM, and add guidance specifically for AI coding agents.

Documentation:
- Add README documentation explaining that async ORM access shares a single connection per alias and that queries are serialized unless independent connections are used.
- Describe in the README that key ORM modules are generated from Django’s source via codemon, are committed to git, and should be modified via codemon config and regeneration rather than direct edits.
- Introduce AGENTS.md with condensed reminders for AI coding agents about the non-parallel async concurrency model and the generated nature of parts of the ORM.