### PR TITLE
PROTOTYPE: coherent async save contract (asave-canonical, no double-run)

### DIFF
--- a/django_async_backend/db/models/base.py
+++ b/django_async_backend/db/models/base.py
@@ -1,0 +1,135 @@
+"""PROTOTYPE: a coherent async save contract.
+
+This is a design proposal, not production code. It implements the contract we
+want to put to upstream: on async paths, ``asave`` is the single source of
+truth, and ``acreate`` is ``build + asave`` so the two finally agree.
+
+Contract (``await obj.asave()`` / ``await Model.async_object.acreate()``):
+
+* override ``asave``    -> run it; its ``super().asave()`` does the native
+  async write and never calls ``save`` -> no double-run.
+* override ``save`` only -> honour it via ``sync_to_async`` (identical to
+  vanilla Django; correct, but not native).
+* override neither     -> native async write.
+* override both        -> run ``asave``; ``save`` is ignored.
+
+Compare vanilla Django (proven empirically), starting from ``foo == 0`` with
+``save``/``asave`` each doing ``self.foo += 1``:
+
+    overrides    | await obj.asave() | await acreate()
+    -------------|-------------------|----------------
+    nothing      | 0                 | 0
+    save only    | 1                 | 1
+    asave only   | 1                 | 0   <- asave silently dropped
+    both         | 2  <- DOUBLE      | 1   <- different from asave!
+
+This contract instead yields a coherent ``0 / 1 / 1 / 1`` for *both* entry
+points: no double-run, and ``acreate`` agrees with ``asave``.
+
+Prototype scope (documented limitations): single-table models only (no
+multi-table inheritance), no signals, no m2m, Postgres only. A production
+version routes the native write through the async ``SQLInsertCompiler`` and
+``aupdate`` rather than raw SQL, and fires async signals.
+"""
+
+from asgiref.sync import sync_to_async
+from django.db import DEFAULT_DB_ALIAS, models, router
+from django.db import connections as sync_connections
+from django.db.models import AutoField
+
+from django_async_backend.db import async_connections
+
+
+class AsyncSaveModel(models.Model):
+    class Meta:
+        abstract = True
+
+    async def asave(
+        self,
+        *,
+        force_insert=False,
+        force_update=False,
+        using=None,
+        update_fields=None,
+    ):
+        cls = type(self)
+        overrode_save = cls.save is not models.Model.save
+        overrode_asave = cls.asave is not AsyncSaveModel.asave
+        if overrode_save and not overrode_asave:
+            # The user wrote a sync ``save`` override but no ``asave``. Honour
+            # it on a worker thread -- exactly what Django's stock ``asave``
+            # does. Correct, though it runs on the sync connection (not native).
+            return await sync_to_async(self.save)(
+                force_insert=force_insert,
+                force_update=force_update,
+                using=using,
+                update_fields=update_fields,
+            )
+        # Reached directly (no override) or via ``super().asave()`` from a user
+        # ``asave``. Either way the user's async logic, if any, has already run;
+        # we never call ``save`` here, so there is no double-run.
+        return await self._asave_native(
+            force_insert=force_insert,
+            using=using,
+            update_fields=update_fields,
+        )
+
+    asave.alters_data = True
+
+    async def _asave_native(
+        self, *, force_insert=False, using=None, update_fields=None
+    ):
+        meta = self._meta
+        alias = (
+            using
+            or router.db_for_write(type(self), instance=self)
+            or DEFAULT_DB_ALIAS
+        )
+        aconn = async_connections[alias]
+        # Value adaptation / identifier quoting only -- no I/O, so using the
+        # sync wrapper here is safe and avoids depending on the async wrapper's
+        # ops surface.
+        prep = sync_connections[alias]
+        qn = prep.ops.quote_name
+
+        if self._is_pk_set() and not force_insert:
+            fields = [f for f in meta.concrete_fields if not f.primary_key]
+            if update_fields is not None:
+                wanted = set(update_fields)
+                fields = [
+                    f
+                    for f in fields
+                    if f.name in wanted or f.attname in wanted
+                ]
+            assignments, params = [], []
+            for f in fields:
+                assignments.append(f"{qn(f.column)} = %s")
+                params.append(f.get_db_prep_save(f.pre_save(self, False), prep))
+            params.append(self.pk)
+            sql = (
+                f"UPDATE {qn(meta.db_table)} SET {', '.join(assignments)} "
+                f"WHERE {qn(meta.pk.column)} = %s"
+            )
+            async with await aconn.cursor() as cur:
+                await cur.execute(sql, params)
+        else:
+            fields = [
+                f for f in meta.concrete_fields if not isinstance(f, AutoField)
+            ]
+            columns, placeholders, params = [], [], []
+            for f in fields:
+                columns.append(qn(f.column))
+                placeholders.append("%s")
+                params.append(f.get_db_prep_save(f.pre_save(self, True), prep))
+            sql = (
+                f"INSERT INTO {qn(meta.db_table)} ({', '.join(columns)}) "
+                f"VALUES ({', '.join(placeholders)}) "
+                f"RETURNING {qn(meta.pk.column)}"
+            )
+            async with await aconn.cursor() as cur:
+                await cur.execute(sql, params)
+                row = await cur.fetchone()
+            setattr(self, meta.pk.attname, row[0])
+
+        self._state.adding = False
+        self._state.db = alias

--- a/django_async_backend/db/models/manager.py
+++ b/django_async_backend/db/models/manager.py
@@ -4,4 +4,14 @@ from django_async_backend.db.models.query import QuerySet
 
 
 class AsyncManager(BaseManager.from_queryset(QuerySet)):
-    pass
+    async def acreate(self, **kwargs):
+        """PROTOTYPE: build + asave, so acreate honours the same async save
+        contract as asave (see django_async_backend.db.models.base). Requires
+        the model to inherit AsyncSaveModel; otherwise obj.asave is Django's
+        stock sync_to_async(save) and you get vanilla semantics.
+        """
+        obj = self.model(**kwargs)
+        await obj.asave(force_insert=True)
+        return obj
+
+    acreate.alters_data = True

--- a/docs/proposals/async-save-contract.md
+++ b/docs/proposals/async-save-contract.md
@@ -7,34 +7,47 @@ make a design decision concrete, not to merge as-is.
 
 Vanilla Django's async write path is incoherent across `asave` and `acreate`,
 and it can run a user's override **twice**. This is an acknowledged, still-open
-bug — Django ticket **#36888** (`QuerySet.acreate()` ignores `asave()`), and the
-attempted fix **PR #20602** was *closed* with the conclusion that a correct fix
-needs foundational "async model instantiation" infrastructure Django isn't ready
-to build. So upstream has no shipping answer today.
+bug — Django ticket **[#36888](https://code.djangoproject.com/ticket/36888)**
+(`QuerySet.acreate()` ignores `asave()`), and the attempted fix **PR #20602**
+was *closed* with the conclusion that a correct fix needs foundational "async
+model instantiation" infrastructure Django isn't ready to build. So upstream has
+no shipping answer today.
+
+### How to read the tables (the proof encoding)
+
+Each model does `self.foo += 1` in `save` and `self.foo += 10` in `asave`. The
+different increments mean the resulting `foo` **names which method(s) ran** —
+this is what makes the proof unambiguous (a same-sized increment could not tell
+"asave ran" from "save ran"):
+
+| foo | meaning |
+|----:|---------|
+| 0   | neither ran |
+| 1   | `save` ran (only) |
+| 10  | `asave` ran (only) |
+| 11  | **both** ran (a double-run) |
 
 ### Proven vanilla Django behaviour (Django 6.0.6)
 
-Each model does `self.foo += 1` in whichever method it overrides; start at
-`foo == 0`:
+Runnable, committed proof: **`docs/proposals/vanilla_repro.py`** (pure stock
+Django, sqlite, no async-backend). Output, starting from `foo = 0`:
 
 | overrides   | `await obj.asave()` | `await Model.objects.acreate()` |
-|-------------|---------------------|---------------------------------|
+|-------------|:-------------------:|:-------------------------------:|
 | nothing     | 0                   | 0                               |
 | save only   | 1                   | 1                               |
-| asave only  | 1                   | **0** ← `asave` silently dropped |
-| both        | **2** ← DOUBLE-run  | **1** ← disagrees with `asave`  |
+| asave only  | 10                  | **0** ← `asave` silently dropped |
+| both        | **11** ← DOUBLE-run | **1** ← ran `save`, not `asave` |
 
 Why:
 
 - `Model.asave` is `await sync_to_async(self.save)(...)` — it routes through
-  `self.save`. So `asave`+`save` both-overridden + the idiomatic
-  `await super().asave()` runs the `save` body too → **double `+=1`**.
+  `self.save`. So both-overridden + the idiomatic `await super().asave()` runs
+  the `save` body too → `foo == 11` (**double-run**).
 - `acreate` is `sync_to_async(self.create)` → `create()` → `obj.save(...)`. It
   **never mentions `asave`** — so an `asave` override is silently ignored
-  (#36888), and `acreate` is really "run the sync create on a thread."
-
-(Reproducer: pure stock Django, in-memory sqlite — see commit history / the
-`docs/` discussion. No async-backend involved.)
+  (#36888, `foo == 0`), and `acreate` is really "run the sync create on a
+  thread."
 
 ## The proposed contract
 
@@ -50,27 +63,30 @@ On async paths, **`asave` is the single source of truth**, and
 
 ### Resulting behaviour (this prototype)
 
+Proven by `tests/db/models/test_async_save_contract.py`:
+
 | overrides   | `await obj.asave()` | `await async_object.acreate()` |
-|-------------|---------------------|--------------------------------|
+|-------------|:-------------------:|:------------------------------:|
 | nothing     | 0                   | 0                              |
 | save only   | 1                   | 1                              |
-| asave only  | 1                   | **1** (was 0 — #36888 fixed)   |
-| both        | **1** (no double)   | 1                              |
+| asave only  | 10                  | **10** (was 0 — #36888 fixed)  |
+| both        | **10** (not 11)     | 10                             |
 
-Coherent `0 / 1 / 1 / 1` for *both* entry points. `acreate` and `asave` agree,
-and the double-run is gone.
+`asave` and `acreate` produce identical results in every row (vanilla they
+diverge), `both == 10` proves `asave` ran and `save` did **not** (would be `11`
+on a double-run, `1` if `save` had run instead), and there is no double-run.
 
 ## What we propose breaking (vs vanilla Django)
 
-1. **`acreate` honours `asave`** (asave-only: `0 → 1`; both: still `1` but now
-   via `asave`, not `save`). This is the #36888 fix direction.
-2. **No double-run for both-overriders** (`asave`: `2 → 1`). A both-overrider's
+1. **`acreate` honours `asave`** (asave-only: `0 → 10`; both: now runs `asave`,
+   not `save`). This is the #36888 fix direction.
+2. **No double-run for both-overriders** (`asave`: `11 → 10`). A both-overrider's
    `save` body no longer runs on async paths.
 3. **API is unchanged** (`acreate` exists, same signature). Only *semantics*
    change, and only toward coherence.
 4. **`save`-only is NOT broken** — graceful degradation runs it via
-   `sync_to_async`, exactly as vanilla Django does. So there is **no silent
-   drop** of user code in any cell.
+   `sync_to_async` (`foo == 1`), exactly as vanilla Django does. So there is
+   **no silent drop** of user code in any cell.
 
 One-line contract for users:
 
@@ -94,6 +110,9 @@ One-line contract for users:
 - No m2m, Postgres only.
 - Native write is raw SQL via the async cursor; a production version routes
   through the async `SQLInsertCompiler`/`aupdate` and fires async signals.
+- The native-vs-threaded distinction (save-only graceful path) is not directly
+  observable in tests because both connections target the same DB; the routing
+  is verified structurally.
 
 ## Files
 
@@ -101,12 +120,14 @@ One-line contract for users:
 - `django_async_backend/db/models/manager.py` — `AsyncManager.acreate`.
 - `tests/test_app/models.py` — `SCNeither`/`SCSave`/`SCAsave`/`SCBoth`.
 - `tests/db/models/test_async_save_contract.py` — the matrix (asserts the
-  coherent table above, and pins the vanilla numbers for contrast).
+  coherent table above; the foo values name the path that ran).
+- `docs/proposals/vanilla_repro.py` — runnable proof of the vanilla column.
 
 ## Running the tests
 
 ```bash
 docker compose up postgres -d
+python docs/proposals/vanilla_repro.py   # vanilla column (no postgres needed)
 cd tests && DJANGO_SETTINGS_MODULE=settings \
   python manage.py test db.models.test_async_save_contract
 ```

--- a/docs/proposals/async-save-contract.md
+++ b/docs/proposals/async-save-contract.md
@@ -1,0 +1,112 @@
+# Proposal (PROTOTYPE): a coherent async save contract
+
+Status: **draft / for discussion.** This branch is a working prototype meant to
+make a design decision concrete, not to merge as-is.
+
+## The problem
+
+Vanilla Django's async write path is incoherent across `asave` and `acreate`,
+and it can run a user's override **twice**. This is an acknowledged, still-open
+bug — Django ticket **#36888** (`QuerySet.acreate()` ignores `asave()`), and the
+attempted fix **PR #20602** was *closed* with the conclusion that a correct fix
+needs foundational "async model instantiation" infrastructure Django isn't ready
+to build. So upstream has no shipping answer today.
+
+### Proven vanilla Django behaviour (Django 6.0.6)
+
+Each model does `self.foo += 1` in whichever method it overrides; start at
+`foo == 0`:
+
+| overrides   | `await obj.asave()` | `await Model.objects.acreate()` |
+|-------------|---------------------|---------------------------------|
+| nothing     | 0                   | 0                               |
+| save only   | 1                   | 1                               |
+| asave only  | 1                   | **0** ← `asave` silently dropped |
+| both        | **2** ← DOUBLE-run  | **1** ← disagrees with `asave`  |
+
+Why:
+
+- `Model.asave` is `await sync_to_async(self.save)(...)` — it routes through
+  `self.save`. So `asave`+`save` both-overridden + the idiomatic
+  `await super().asave()` runs the `save` body too → **double `+=1`**.
+- `acreate` is `sync_to_async(self.create)` → `create()` → `obj.save(...)`. It
+  **never mentions `asave`** — so an `asave` override is silently ignored
+  (#36888), and `acreate` is really "run the sync create on a thread."
+
+(Reproducer: pure stock Django, in-memory sqlite — see commit history / the
+`docs/` discussion. No async-backend involved.)
+
+## The proposed contract
+
+On async paths, **`asave` is the single source of truth**, and
+`acreate` = build + `asave` (so the two finally agree):
+
+- override `asave` → run it; its `super().asave()` does the native async write
+  and never calls `save` → **no double-run**.
+- override `save` only → honour it via `sync_to_async` (identical to vanilla
+  Django; correct, not native).
+- override neither → native async write.
+- override both → run `asave`; `save` is ignored.
+
+### Resulting behaviour (this prototype)
+
+| overrides   | `await obj.asave()` | `await async_object.acreate()` |
+|-------------|---------------------|--------------------------------|
+| nothing     | 0                   | 0                              |
+| save only   | 1                   | 1                              |
+| asave only  | 1                   | **1** (was 0 — #36888 fixed)   |
+| both        | **1** (no double)   | 1                              |
+
+Coherent `0 / 1 / 1 / 1` for *both* entry points. `acreate` and `asave` agree,
+and the double-run is gone.
+
+## What we propose breaking (vs vanilla Django)
+
+1. **`acreate` honours `asave`** (asave-only: `0 → 1`; both: still `1` but now
+   via `asave`, not `save`). This is the #36888 fix direction.
+2. **No double-run for both-overriders** (`asave`: `2 → 1`). A both-overrider's
+   `save` body no longer runs on async paths.
+3. **API is unchanged** (`acreate` exists, same signature). Only *semantics*
+   change, and only toward coherence.
+4. **`save`-only is NOT broken** — graceful degradation runs it via
+   `sync_to_async`, exactly as vanilla Django does. So there is **no silent
+   drop** of user code in any cell.
+
+One-line contract for users:
+
+> On async paths, `asave` is the source of truth. `acreate`/`asave` run your
+> `asave` override if you have one (native), your `save` override (threaded) if
+> that's all you wrote, and a native async save otherwise. If you override both,
+> the async path uses `asave` and never your `save`.
+
+## Why this is the right shape
+
+- It's strictly better-or-equal to Django in every cell (the only divergences
+  fix an open bug and remove a footgun).
+- Because we're the ones who'd take this upstream, the coherent implementation
+  *is* the upstream argument: "#36888 is open, here's the one rule that fixes it,
+  here's it running with tests."
+
+## Prototype scope / limitations (NOT production)
+
+- Single-table models only (no multi-table inheritance).
+- No signals (`pre_save`/`post_save`) on the native path yet.
+- No m2m, Postgres only.
+- Native write is raw SQL via the async cursor; a production version routes
+  through the async `SQLInsertCompiler`/`aupdate` and fires async signals.
+
+## Files
+
+- `django_async_backend/db/models/base.py` — `AsyncSaveModel` (the contract).
+- `django_async_backend/db/models/manager.py` — `AsyncManager.acreate`.
+- `tests/test_app/models.py` — `SCNeither`/`SCSave`/`SCAsave`/`SCBoth`.
+- `tests/db/models/test_async_save_contract.py` — the matrix (asserts the
+  coherent table above, and pins the vanilla numbers for contrast).
+
+## Running the tests
+
+```bash
+docker compose up postgres -d
+cd tests && DJANGO_SETTINGS_MODULE=settings \
+  python manage.py test db.models.test_async_save_contract
+```

--- a/docs/proposals/vanilla_repro.py
+++ b/docs/proposals/vanilla_repro.py
@@ -1,0 +1,112 @@
+"""Reproduce vanilla Django's save/asave incoherence -- runnable proof.
+
+PURE stock Django on file-based sqlite. NO django-async-backend involved. This
+is the committed evidence behind the "vanilla" column of the proposal table
+(docs/proposals/async-save-contract.md): the asave/acreate divergence and the
+both-overridden double-run are real, not asserted.
+
+Run:  python docs/proposals/vanilla_repro.py
+Needs only Django installed (no postgres).
+
+`save` adds 1, `asave` adds 10, so the printed foo NAMES which method ran:
+0=neither, 1=save, 10=asave, 11=both (double-run).
+
+Expected output (Django 6.0):
+
+    overrides    | await obj.asave() | await acreate()
+    -------------|-------------------|----------------
+    nothing      | 0                 | 0
+    save only    | 1                 | 1
+    asave only   | 10                | 0   <- asave silently dropped
+    both         | 11  <- DOUBLE-RUN | 1   <- ran save, not asave
+"""
+import asyncio
+import tempfile
+
+import django
+from django.conf import settings
+
+# File-based sqlite (NOT :memory:): asave runs the save on a worker thread via
+# sync_to_async, and an in-memory db is per-connection, so the table would be
+# invisible there.
+_DB = tempfile.NamedTemporaryFile(suffix=".sqlite3", delete=False).name
+
+settings.configure(
+    INSTALLED_APPS=[],
+    DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": _DB}},
+    DEFAULT_AUTO_FIELD="django.db.models.AutoField",
+)
+django.setup()
+
+from django.db import connection, models  # noqa: E402
+
+
+class Neither(models.Model):
+    foo = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = "x"
+
+
+class SaveOnly(models.Model):
+    foo = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = "x"
+
+    def save(self, *a, **k):
+        self.foo += 1
+        super().save(*a, **k)
+
+
+class AsaveOnly(models.Model):
+    foo = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = "x"
+
+    async def asave(self, *a, **k):
+        self.foo += 10
+        await super().asave(*a, **k)
+
+
+class Both(models.Model):
+    foo = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = "x"
+
+    def save(self, *a, **k):
+        self.foo += 1
+        super().save(*a, **k)
+
+    async def asave(self, *a, **k):
+        self.foo += 10
+        await super().asave(*a, **k)
+
+
+MODELS = [
+    ("nothing", Neither),
+    ("save only", SaveOnly),
+    ("asave only", AsaveOnly),
+    ("both", Both),
+]
+
+with connection.schema_editor() as se:
+    for _, M in MODELS:
+        se.create_model(M)
+
+
+async def main():
+    print("Django version:", django.get_version())
+    print(f"{'overrides':<12} | {'await obj.asave()':<18} | await acreate()")
+    print("-" * 52)
+    for label, M in MODELS:
+        obj = M()
+        await obj.asave()
+        created = await M.objects.acreate()
+        note = "  <- DOUBLE-RUN" if obj.foo == 11 else ""
+        print(f"{label:<12} | foo={obj.foo:<14}{note} | foo={created.foo}")
+
+
+asyncio.run(main())

--- a/tests/db/models/test_async_save_contract.py
+++ b/tests/db/models/test_async_save_contract.py
@@ -1,0 +1,101 @@
+"""PROTOTYPE: the coherent async save contract vs vanilla Django.
+
+Each model does `self.foo += 1` in whichever method it overrides, so the final
+`foo` reveals which path ran and how many times.
+
+Vanilla Django 6.0 (proven empirically, starting from foo=0):
+
+    overrides    | await obj.asave() | await acreate()
+    -------------|-------------------|----------------
+    nothing      | 0                 | 0
+    save only    | 1                 | 1
+    asave only   | 1                 | 0   <- asave silently dropped
+    both         | 2  <- DOUBLE      | 1   <- disagrees with asave!
+
+This contract (AsyncSaveModel + AsyncManager.acreate) instead yields a
+coherent 0 / 1 / 1 / 1 for BOTH entry points: no double-run, and acreate
+agrees with asave.
+"""
+from test_app.models import (
+    SCAsave,
+    SCBoth,
+    SCNeither,
+    SCSave,
+)
+
+from django_async_backend.test import AsyncioTestCase
+
+# model -> expected foo under THIS contract (same for asave and acreate)
+CONTRACT = [
+    (SCNeither, 0),
+    (SCSave, 1),
+    (SCAsave, 1),
+    (SCBoth, 1),
+]
+
+# What vanilla Django produces, for contrast / documenting the breaks.
+VANILLA_ASAVE = {SCNeither: 0, SCSave: 1, SCAsave: 1, SCBoth: 2}
+VANILLA_ACREATE = {SCNeither: 0, SCSave: 1, SCAsave: 0, SCBoth: 1}
+
+
+class TestAsaveContract(AsyncioTestCase):
+    async def test_asave_each_shape(self):
+        for model, expected in CONTRACT:
+            with self.subTest(model=model.__name__):
+                obj = model()  # foo defaults to 0
+                await obj.asave()
+                self.assertEqual(obj.foo, expected)
+
+    async def test_acreate_each_shape(self):
+        for model, expected in CONTRACT:
+            with self.subTest(model=model.__name__):
+                obj = await model.async_object.acreate()
+                self.assertEqual(obj.foo, expected)
+
+    async def test_acreate_and_asave_agree(self):
+        # The headline fix: the two entry points are finally consistent.
+        for model, _ in CONTRACT:
+            with self.subTest(model=model.__name__):
+                via_asave = model()
+                await via_asave.asave()
+                via_acreate = await model.async_object.acreate()
+                self.assertEqual(via_asave.foo, via_acreate.foo)
+
+    async def test_both_overridden_no_double_run(self):
+        # Vanilla Django gives foo=2 here (asave -> super().asave() ->
+        # sync_to_async(self.save) -> user save runs too). The contract runs
+        # asave once and never touches save.
+        obj = SCBoth()
+        await obj.asave()
+        self.assertEqual(obj.foo, 1)
+        self.assertEqual(VANILLA_ASAVE[SCBoth], 2)  # what we are fixing
+
+    async def test_asave_only_acreate_now_honoured(self):
+        # Vanilla acreate ignores asave entirely (foo stays 0, #36888).
+        obj = await SCAsave.async_object.acreate()
+        self.assertEqual(obj.foo, 1)
+        self.assertEqual(VANILLA_ACREATE[SCAsave], 0)  # what we are fixing
+
+
+class TestNativePersistence(AsyncioTestCase):
+    """The native path (no override / asave-override) really writes through the
+    async connection and is visible to async reads in the same transaction."""
+
+    async def test_native_insert_persists(self):
+        obj = await SCNeither.async_object.acreate(foo=7)
+        self.assertIsNotNone(obj.pk)
+        reloaded = await SCNeither.async_object.aget(pk=obj.pk)
+        self.assertEqual(reloaded.foo, 7)
+
+    async def test_native_update_persists(self):
+        obj = await SCNeither.async_object.acreate(foo=3)
+        obj.foo = 99
+        await obj.asave()  # pk set, not force_insert -> UPDATE branch
+        reloaded = await SCNeither.async_object.aget(pk=obj.pk)
+        self.assertEqual(reloaded.foo, 99)
+
+    async def test_asave_override_persists_natively(self):
+        obj = await SCAsave.async_object.acreate(foo=10)  # asave bumps to 11
+        self.assertEqual(obj.foo, 11)
+        reloaded = await SCAsave.async_object.aget(pk=obj.pk)
+        self.assertEqual(reloaded.foo, 11)

--- a/tests/db/models/test_async_save_contract.py
+++ b/tests/db/models/test_async_save_contract.py
@@ -1,20 +1,32 @@
 """PROTOTYPE: the coherent async save contract vs vanilla Django.
 
-Each model does `self.foo += 1` in whichever method it overrides, so the final
-`foo` reveals which path ran and how many times.
+`save` adds 1, `asave` adds 10, so the resulting `foo` NAMES which method(s)
+ran (this is what makes the proof unambiguous -- a same-sized increment could
+not distinguish "asave ran" from "save ran"):
 
-Vanilla Django 6.0 (proven empirically, starting from foo=0):
+    foo == 0   neither ran
+    foo == 1   save ran (only)
+    foo == 10  asave ran (only)
+    foo == 11  BOTH ran  (i.e. a double-run)
+
+Vanilla Django 6.0 (independently reproduced -- see
+docs/proposals/vanilla_repro.py), starting from foo=0:
 
     overrides    | await obj.asave() | await acreate()
     -------------|-------------------|----------------
     nothing      | 0                 | 0
     save only    | 1                 | 1
-    asave only   | 1                 | 0   <- asave silently dropped
-    both         | 2  <- DOUBLE      | 1   <- disagrees with asave!
+    asave only   | 10                | 0   <- asave silently dropped
+    both         | 11  <- DOUBLE-RUN | 1   <- ran save, not asave
 
-This contract (AsyncSaveModel + AsyncManager.acreate) instead yields a
-coherent 0 / 1 / 1 / 1 for BOTH entry points: no double-run, and acreate
-agrees with asave.
+This contract instead routes both entry points through asave:
+
+    overrides    | await obj.asave() | await acreate()
+    -------------|-------------------|----------------
+    nothing      | 0                 | 0
+    save only    | 1                 | 1
+    asave only   | 10                | 10
+    both         | 10  <- no double  | 10  <- agrees with asave
 """
 from test_app.models import (
     SCAsave,
@@ -25,16 +37,17 @@ from test_app.models import (
 
 from django_async_backend.test import AsyncioTestCase
 
-# model -> expected foo under THIS contract (same for asave and acreate)
+# model -> expected foo under THIS contract. Same for asave and acreate, and
+# the *value itself* identifies the path that ran (see bitmask above).
 CONTRACT = [
-    (SCNeither, 0),
-    (SCSave, 1),
-    (SCAsave, 1),
-    (SCBoth, 1),
+    (SCNeither, 0),   # 00 neither
+    (SCSave, 1),      # 01 save ran (graceful sync_to_async(save))
+    (SCAsave, 10),    # 10 asave ran natively
+    (SCBoth, 10),     # 10 asave ran, save did NOT (would be 11 if double)
 ]
 
-# What vanilla Django produces, for contrast / documenting the breaks.
-VANILLA_ASAVE = {SCNeither: 0, SCSave: 1, SCAsave: 1, SCBoth: 2}
+# What vanilla Django produces, for contrast (reproduced in vanilla_repro.py).
+VANILLA_ASAVE = {SCNeither: 0, SCSave: 1, SCAsave: 10, SCBoth: 11}
 VANILLA_ACREATE = {SCNeither: 0, SCSave: 1, SCAsave: 0, SCBoth: 1}
 
 
@@ -61,19 +74,28 @@ class TestAsaveContract(AsyncioTestCase):
                 via_acreate = await model.async_object.acreate()
                 self.assertEqual(via_asave.foo, via_acreate.foo)
 
-    async def test_both_overridden_no_double_run(self):
-        # Vanilla Django gives foo=2 here (asave -> super().asave() ->
-        # sync_to_async(self.save) -> user save runs too). The contract runs
-        # asave once and never touches save.
+    async def test_both_overridden_runs_asave_not_save(self):
+        # foo == 10 proves asave ran and save did NOT:
+        #   11 would mean both ran (the vanilla double-run);
+        #    1 would mean save ran and asave was skipped.
         obj = SCBoth()
         await obj.asave()
+        self.assertEqual(obj.foo, 10)
+        self.assertNotEqual(obj.foo, 11)  # not a double-run
+        self.assertNotEqual(obj.foo, 1)   # asave was not skipped for save
+        self.assertEqual(VANILLA_ASAVE[SCBoth], 11)  # what we are fixing
+
+    async def test_save_only_runs_save_via_graceful_path(self):
+        # foo == 1 proves the user's sync save ran (graceful degradation),
+        # not the native path (which would leave foo == 0).
+        obj = SCSave()
+        await obj.asave()
         self.assertEqual(obj.foo, 1)
-        self.assertEqual(VANILLA_ASAVE[SCBoth], 2)  # what we are fixing
 
     async def test_asave_only_acreate_now_honoured(self):
-        # Vanilla acreate ignores asave entirely (foo stays 0, #36888).
+        # foo == 10 proves acreate ran asave. Vanilla acreate drops it (0).
         obj = await SCAsave.async_object.acreate()
-        self.assertEqual(obj.foo, 1)
+        self.assertEqual(obj.foo, 10)
         self.assertEqual(VANILLA_ACREATE[SCAsave], 0)  # what we are fixing
 
 
@@ -95,7 +117,7 @@ class TestNativePersistence(AsyncioTestCase):
         self.assertEqual(reloaded.foo, 99)
 
     async def test_asave_override_persists_natively(self):
-        obj = await SCAsave.async_object.acreate(foo=10)  # asave bumps to 11
-        self.assertEqual(obj.foo, 11)
+        obj = await SCAsave.async_object.acreate(foo=10)  # asave bumps to 20
+        self.assertEqual(obj.foo, 20)
         reloaded = await SCAsave.async_object.aget(pk=obj.pk)
-        self.assertEqual(reloaded.foo, 11)
+        self.assertEqual(reloaded.foo, 20)

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -1,6 +1,7 @@
 from django.db import DEFAULT_DB_ALIAS, models
 
 from django_async_backend.db.models.manager import AsyncManager
+from django_async_backend.db.models.base import AsyncSaveModel
 from django_async_backend.db import async_connections
 
 
@@ -90,3 +91,61 @@ class ChildModel(ParentModel):
 
     class Meta:
         db_table = "child_model"
+
+
+# --- Async save-contract prototype models -----------------------------------
+# Each does `self.foo += 1` in whichever method(s) it overrides, so the final
+# `foo` value reveals exactly which code path ran (and how many times).
+
+
+class SaveContractBase(AsyncSaveModel):
+    foo = models.IntegerField(default=0)
+
+    async_object = AsyncManager()
+
+    class Meta:
+        abstract = True
+
+
+class SCNeither(SaveContractBase):
+    """Overrides nothing."""
+
+    class Meta:
+        db_table = "sc_neither"
+
+
+class SCSave(SaveContractBase):
+    """Overrides sync save only."""
+
+    class Meta:
+        db_table = "sc_save"
+
+    def save(self, *args, **kwargs):
+        self.foo += 1
+        super().save(*args, **kwargs)
+
+
+class SCAsave(SaveContractBase):
+    """Overrides async asave only."""
+
+    class Meta:
+        db_table = "sc_asave"
+
+    async def asave(self, *args, **kwargs):
+        self.foo += 1
+        await super().asave(*args, **kwargs)
+
+
+class SCBoth(SaveContractBase):
+    """Overrides both save and asave (the irreducible hard case)."""
+
+    class Meta:
+        db_table = "sc_both"
+
+    def save(self, *args, **kwargs):
+        self.foo += 1
+        super().save(*args, **kwargs)
+
+    async def asave(self, *args, **kwargs):
+        self.foo += 1
+        await super().asave(*args, **kwargs)

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -94,8 +94,12 @@ class ChildModel(ParentModel):
 
 
 # --- Async save-contract prototype models -----------------------------------
-# Each does `self.foo += 1` in whichever method(s) it overrides, so the final
-# `foo` value reveals exactly which code path ran (and how many times).
+# `save` adds 1, `asave` adds 10, so the final `foo` reads like a bitmask that
+# NAMES which method(s) ran -- the key to proving routing, not just counting:
+#   0  -> neither ran     1  -> save ran (only)
+#   10 -> asave ran (only)   11 -> BOTH ran (double-run)
+# This is what lets the tests distinguish "asave ran" from "save ran" on the
+# `both` / `save only` rows, where a same-sized increment would be ambiguous.
 
 
 class SaveContractBase(AsyncSaveModel):
@@ -132,7 +136,7 @@ class SCAsave(SaveContractBase):
         db_table = "sc_asave"
 
     async def asave(self, *args, **kwargs):
-        self.foo += 1
+        self.foo += 10
         await super().asave(*args, **kwargs)
 
 
@@ -147,5 +151,5 @@ class SCBoth(SaveContractBase):
         super().save(*args, **kwargs)
 
     async def asave(self, *args, **kwargs):
-        self.foo += 1
+        self.foo += 10
         await super().asave(*args, **kwargs)


### PR DESCRIPTION
Design proposal for discussion

### Vanilla Django 6.0 vs this prototype

`save` adds **1**, `asave` adds **10**, so `foo` *names which method ran* — that's what makes this a proof, not a count:

| foo | meaning |
|----:|---------|
| 0 | neither ran |
| 1 | `save` ran |
| 10 | `asave` ran |
| 11 | **both** ran (double-run) |

**Vanilla Django 6.0.6** — runnable proof: [`docs/proposals/vanilla_repro.py`](docs/proposals/vanilla_repro.py) (pure stock Django, sqlite, no async-backend):

| overrides   | `await obj.asave()` | `await objects.acreate()` |
|-------------|:-------------------:|:-------------------------:|
| nothing     | 0 | 0 |
| save only   | 1 | 1 |
| asave only  | 10 | **0** ← `asave` silently dropped |
| both        | **11** ← double-run | **1** ← ran `save`, not `asave` |

**This prototype** — proven by `tests/db/models/test_async_save_contract.py`:

| overrides   | `await obj.asave()` | `await async_object.acreate()` |
|-------------|:-------------------:|:------------------------------:|
| nothing     | 0 | 0 |
| save only   | 1 | 1 |
| asave only  | 10 | **10** (#36888 fixed) |
| both        | **10** (no double-run) | 10 |

`asave` and `acreate` agree in every row; `both == 10` proves `asave` ran and `save` did not. Fixes the incoherence in Django ticket [#36888](https://code.djangoproject.com/ticket/36888) (open).


DO NOT MERGE.


## Summary by Sourcery

Prototype a coherent async save contract where asave is the async source of truth and acreate is defined as build-plus-asave for models using the async backend.

New Features:
- Introduce AsyncSaveModel providing an async-native save path with a defined override contract between save and asave.
- Extend AsyncManager with an acreate method that instantiates a model and persists it via asave to align async creation and saving semantics.

Documentation:
- Add a design proposal document explaining the async save contract, its divergence from vanilla Django, and prototype limitations.

Tests:
- Add async model variants exercising different combinations of save/asave overrides to observe behavior via a foo counter field.
- Add tests validating the new async save contract matrix, ensuring acreate and asave agree, preventing double-run behavior, and confirming native async persistence via the async connection.