### PR TITLE
queryset: add abulk_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ async def main():
 | `Model.objects.acount`              | ✅        |          |
 | `Model.objects.none`                | ✅        |          |
 | `Model.objects.abulk_create`        | ✅        |          |
-| `Model.objects.abulk_update`        | ❌        |          |
+| `Model.objects.abulk_update`        | ✅        |          |
 | `Model.objects.aget_or_create`      | ✅        |          |
 | `Model.objects.aupdate_or_create`   | ❌        |          |
 | `Model.objects.aearliest`           | ✅        |          |

--- a/codemon/config/db__models__query.yaml
+++ b/codemon/config/db__models__query.yaml
@@ -263,6 +263,23 @@ module:
                   attr: async_save
               to_await: true
 
+        _prepare_for_bulk_create:
+          to_async: true
+          calls:
+            - func:
+                value: obj
+                attr: _is_pk_set
+              rename:
+                func:
+                  attr: _async_is_pk_set
+            - func:
+                value: obj
+                attr: _prepare_related_fields_for_save
+              rename:
+                func:
+                  attr: _async_prepare_related_fields_for_save
+              to_await: true
+
         bulk_create:
           to_async: true
           rename: abulk_create
@@ -272,6 +289,9 @@ module:
           context_managers:
             - to_async: true
           calls:
+            - func:
+                attr: _prepare_for_bulk_create
+              to_await: true
             - func:
                 attr: _handle_order_with_respect_to
               to_await: true
@@ -313,6 +333,19 @@ module:
           context_managers:
             - to_async: true
           calls:
+            - func:
+                value: obj
+                attr: _is_pk_set
+              rename:
+                func:
+                  attr: _async_is_pk_set
+            - func:
+                value: obj
+                attr: _prepare_related_fields_for_save
+              rename:
+                func:
+                  attr: _async_prepare_related_fields_for_save
+              to_await: true
             # guard: keeps the set's `all_pk_fields.update()` untouched
             - func:
                 value: all_pk_fields

--- a/codemon/config/db__models__query.yaml
+++ b/codemon/config/db__models__query.yaml
@@ -24,7 +24,7 @@ module:
 
         - target:
             name: bulk_update
-          remove: true
+          rename: abulk_update
 
         - target:
             name: get_or_create
@@ -305,9 +305,30 @@ module:
                 )
 
         bulk_update:
-          # to_async: true
-          # rename: abulk_update
-          remove: true
+          to_async: true
+          rename: abulk_update
+          renames:
+            - name: connections
+              rename: async_connections
+          context_managers:
+            - to_async: true
+          calls:
+            # guard: keeps the set's `all_pk_fields.update()` untouched
+            - func:
+                value: all_pk_fields
+                attr: update
+            - func:
+                attr: update
+              rename:
+                func:
+                  attr: aupdate
+              to_await: true
+            - func:
+                value: transaction
+                attr: atomic
+              rename:
+                func:
+                  name: async_atomic
 
         get_or_create:
           to_async: true

--- a/django_async_backend/db/models/query.py
+++ b/django_async_backend/db/models/query.py
@@ -791,6 +791,78 @@ class QuerySet(AltersData):
 
     abulk_create.alters_data = True
 
+    async def abulk_update(self, objs, fields, batch_size=None):
+        """
+        Update the given fields in each of the given objects in the database.
+        """
+        if batch_size is not None and batch_size <= 0:
+            raise ValueError("Batch size must be a positive integer.")
+        if not fields:
+            raise ValueError("Field names must be given to bulk_update().")
+        objs = tuple(objs)
+        if not all(obj._is_pk_set() for obj in objs):
+            raise ValueError(
+                "All bulk_update() objects must have a primary key set."
+            )
+        opts = self.model._meta
+        fields = [opts.get_field(name) for name in fields]
+        if any(not f.concrete for f in fields):
+            raise ValueError(
+                "bulk_update() can only be used with concrete fields."
+            )
+        all_pk_fields = set(opts.pk_fields)
+        for parent in opts.all_parents:
+            all_pk_fields.update(parent._meta.pk_fields)
+        if any(f in all_pk_fields for f in fields):
+            raise ValueError(
+                "bulk_update() cannot be used with primary key fields."
+            )
+        if not objs:
+            return 0
+        for obj in objs:
+            obj._prepare_related_fields_for_save(
+                operation_name="bulk_update", fields=fields
+            )
+        # PK is used twice in the resulting update query, once in the filter
+        # and once in the WHEN. Each field will also have one CAST.
+        self._for_write = True
+        connection = async_connections[self.db]
+        max_batch_size = connection.ops.bulk_batch_size(
+            [opts.pk, opts.pk, *fields], objs
+        )
+        batch_size = (
+            min(batch_size, max_batch_size) if batch_size else max_batch_size
+        )
+        requires_casting = connection.features.requires_casted_case_in_updates
+        batches = (
+            objs[i : i + batch_size] for i in range(0, len(objs), batch_size)
+        )
+        updates = []
+        for batch_objs in batches:
+            update_kwargs = {}
+            for field in fields:
+                when_statements = []
+                for obj in batch_objs:
+                    attr = getattr(obj, field.attname)
+                    if not hasattr(attr, "resolve_expression"):
+                        attr = Value(attr, output_field=field)
+                    when_statements.append(When(pk=obj.pk, then=attr))
+                case_statement = Case(*when_statements, output_field=field)
+                if requires_casting:
+                    case_statement = Cast(case_statement, output_field=field)
+                update_kwargs[field.attname] = case_statement
+            updates.append(([obj.pk for obj in batch_objs], update_kwargs))
+        rows_updated = 0
+        queryset = self.using(self.db)
+        async with async_atomic(using=self.db, savepoint=False):
+            for pks, update_kwargs in updates:
+                rows_updated += await queryset.filter(pk__in=pks).aupdate(
+                    **update_kwargs
+                )
+        return rows_updated
+
+    abulk_update.alters_data = True
+
     async def aget_or_create(self, defaults=None, **kwargs):
         """
         Look up an object with the given kwargs, creating one if necessary.

--- a/django_async_backend/db/models/query.py
+++ b/django_async_backend/db/models/query.py
@@ -553,20 +553,22 @@ class QuerySet(AltersData):
 
     acreate.alters_data = True
 
-    def _prepare_for_bulk_create(self, objs):
+    async def _prepare_for_bulk_create(self, objs):
         objs_with_pk, objs_without_pk = [], []
         for obj in objs:
             if isinstance(obj.pk, DatabaseDefault):
                 objs_without_pk.append(obj)
-            elif obj._is_pk_set():
+            elif obj._async_is_pk_set():
                 objs_with_pk.append(obj)
             else:
                 obj.pk = obj._meta.pk.get_pk_value_on_save(obj)
-                if obj._is_pk_set():
+                if obj._async_is_pk_set():
                     objs_with_pk.append(obj)
                 else:
                     objs_without_pk.append(obj)
-            obj._prepare_related_fields_for_save(operation_name="bulk_create")
+            await obj._async_prepare_related_fields_for_save(
+                operation_name="bulk_create"
+            )
         return objs_with_pk, objs_without_pk
 
     def _check_bulk_create_options(
@@ -697,7 +699,9 @@ class QuerySet(AltersData):
         self._for_write = True
         fields = [f for f in opts.concrete_fields if not f.generated]
         objs = list(objs)
-        objs_with_pk, objs_without_pk = self._prepare_for_bulk_create(objs)
+        objs_with_pk, objs_without_pk = await self._prepare_for_bulk_create(
+            objs
+        )
         if objs_with_pk and objs_without_pk:
             context = async_atomic(using=self.db, savepoint=False)
         else:
@@ -800,7 +804,7 @@ class QuerySet(AltersData):
         if not fields:
             raise ValueError("Field names must be given to bulk_update().")
         objs = tuple(objs)
-        if not all(obj._is_pk_set() for obj in objs):
+        if not all(obj._async_is_pk_set() for obj in objs):
             raise ValueError(
                 "All bulk_update() objects must have a primary key set."
             )
@@ -820,7 +824,7 @@ class QuerySet(AltersData):
         if not objs:
             return 0
         for obj in objs:
-            obj._prepare_related_fields_for_save(
+            await obj._async_prepare_related_fields_for_save(
                 operation_name="bulk_update", fields=fields
             )
         # PK is used twice in the resulting update query, once in the filter

--- a/tests/db/models/query/test_abulk_update.py
+++ b/tests/db/models/query/test_abulk_update.py
@@ -170,10 +170,11 @@ class TestABulkUpdateValidation(AsyncioTestCase):
             await TestModel.async_objects.all().abulk_update([self.item1], [])
 
     async def test_non_positive_batch_size_raises(self):
-        with self.assertRaises(ValueError):
-            await TestModel.async_objects.all().abulk_update(
-                [self.item1], ["value"], batch_size=0
-            )
+        for batch_size in (0, -1):
+            with self.assertRaises(ValueError):
+                await TestModel.async_objects.all().abulk_update(
+                    [self.item1], ["value"], batch_size=batch_size
+                )
 
     async def test_object_without_pk_raises(self):
         unsaved = TestModel(name="Unsaved", value=1)

--- a/tests/db/models/query/test_abulk_update.py
+++ b/tests/db/models/query/test_abulk_update.py
@@ -1,0 +1,229 @@
+from django.db import DEFAULT_DB_ALIAS, IntegrityError
+from django.db.models import F
+from test_app.models import TestModel
+
+from django_async_backend.db import async_connections
+from django_async_backend.test import (
+    AsyncioTestCase,
+    AsyncioTransactionTestCase,
+)
+
+
+class TestABulkUpdate(AsyncioTestCase):
+    async def asyncSetUp(self):
+        self.item1 = await TestModel.async_objects.acreate(
+            name="Item1", value=1
+        )
+        self.item2 = await TestModel.async_objects.acreate(
+            name="Item2", value=2
+        )
+        self.item3 = await TestModel.async_objects.acreate(
+            name="Item3", value=3
+        )
+
+    async def _values_by_name(self):
+        return {
+            obj.name: obj.value async for obj in TestModel.async_objects.all()
+        }
+
+    async def test_returns_row_count(self):
+        self.item1.value = 10
+        self.item2.value = 20
+        self.item3.value = 30
+        rows = await TestModel.async_objects.all().abulk_update(
+            [self.item1, self.item2, self.item3], ["value"]
+        )
+        self.assertEqual(rows, 3)
+        self.assertEqual(
+            await self._values_by_name(),
+            {"Item1": 10, "Item2": 20, "Item3": 30},
+        )
+
+    async def test_multiple_fields(self):
+        self.item1.name = "New1"
+        self.item1.value = 100
+        self.item2.name = "New2"
+        self.item2.value = 200
+        rows = await TestModel.async_objects.all().abulk_update(
+            [self.item1, self.item2], ["name", "value"]
+        )
+        self.assertEqual(rows, 2)
+        self.assertEqual(
+            await self._values_by_name(),
+            {"New1": 100, "New2": 200, "Item3": 3},
+        )
+
+    async def test_batch_size_forces_multiple_batches(self):
+        # batch_size=1 produces one UPDATE (one awaited aupdate) per object,
+        # exercising the per-batch loop inside `async with async_atomic`.
+        self.item1.value = 7
+        self.item2.value = 7
+        self.item3.value = 7
+        rows = await TestModel.async_objects.all().abulk_update(
+            [self.item1, self.item2, self.item3], ["value"], batch_size=1
+        )
+        self.assertEqual(rows, 3)
+        self.assertEqual(
+            await self._values_by_name(),
+            {"Item1": 7, "Item2": 7, "Item3": 7},
+        )
+
+    async def test_uneven_batches(self):
+        # batch_size=2 over 3 objects exercises the uneven final batch.
+        self.item1.value = 9
+        self.item2.value = 9
+        self.item3.value = 9
+        rows = await TestModel.async_objects.all().abulk_update(
+            [self.item1, self.item2, self.item3], ["value"], batch_size=2
+        )
+        self.assertEqual(rows, 3)
+        self.assertEqual(
+            await self._values_by_name(),
+            {"Item1": 9, "Item2": 9, "Item3": 9},
+        )
+
+    async def test_f_expression_values(self):
+        # An attribute set to a resolvable expression (F) must pass through
+        # unwrapped into the CASE/WHEN rather than being treated as a literal.
+        self.item1.value = F("value") + 100
+        self.item2.value = F("value") + 100
+        self.item3.value = F("value") + 100
+        rows = await TestModel.async_objects.all().abulk_update(
+            [self.item1, self.item2, self.item3], ["value"]
+        )
+        self.assertEqual(rows, 3)
+        self.assertEqual(
+            await self._values_by_name(),
+            {"Item1": 101, "Item2": 102, "Item3": 103},
+        )
+
+    async def test_empty_objs_returns_zero(self):
+        rows = await TestModel.async_objects.all().abulk_update([], ["value"])
+        self.assertEqual(rows, 0)
+        self.assertEqual(
+            await self._values_by_name(),
+            {"Item1": 1, "Item2": 2, "Item3": 3},
+        )
+
+    async def test_manager_level_exposure(self):
+        # abulk_update is surfaced on the manager, not only on querysets.
+        self.item1.value = 50
+        rows = await TestModel.async_objects.abulk_update(
+            [self.item1], ["value"]
+        )
+        self.assertEqual(rows, 1)
+        item = await TestModel.async_objects.aget(name="Item1")
+        self.assertEqual(item.value, 50)
+
+    async def test_duplicate_objects_count_once_per_batch(self):
+        # Duplicates within one batch collapse into a single row match (the
+        # first When wins), so the same pk counts once toward the row count.
+        self.item1.value = 42
+        rows = await TestModel.async_objects.all().abulk_update(
+            [self.item1, self.item1], ["value"]
+        )
+        self.assertEqual(rows, 1)
+        item = await TestModel.async_objects.aget(name="Item1")
+        self.assertEqual(item.value, 42)
+
+    async def test_foreign_key_field(self):
+        # A saved related object passes _prepare_related_fields_for_save and
+        # updates the FK column.
+        self.item2.relative = self.item1
+        rows = await TestModel.async_objects.all().abulk_update(
+            [self.item2], ["relative"]
+        )
+        self.assertEqual(rows, 1)
+        item = await TestModel.async_objects.aget(name="Item2")
+        self.assertEqual(item.relative_id, self.item1.pk)
+
+    async def test_unsaved_related_object_raises(self):
+        self.item2.relative = TestModel(name="Unsaved", value=0)
+        with self.assertRaises(ValueError):
+            await TestModel.async_objects.all().abulk_update(
+                [self.item2], ["relative"]
+            )
+
+    async def test_only_matching_queryset_rows_updated(self):
+        # The batched UPDATE runs through the queryset's own filters, so
+        # objects outside the queryset are not touched.
+        self.item1.value = 111
+        self.item2.value = 222
+        rows = await TestModel.async_objects.filter(
+            name="Item1"
+        ).abulk_update([self.item1, self.item2], ["value"])
+        self.assertEqual(rows, 1)
+        self.assertEqual(
+            await self._values_by_name(),
+            {"Item1": 111, "Item2": 2, "Item3": 3},
+        )
+
+
+class TestABulkUpdateValidation(AsyncioTestCase):
+    async def asyncSetUp(self):
+        self.item1 = await TestModel.async_objects.acreate(
+            name="Item1", value=1
+        )
+
+    async def test_no_fields_raises(self):
+        with self.assertRaises(ValueError):
+            await TestModel.async_objects.all().abulk_update([self.item1], [])
+
+    async def test_non_positive_batch_size_raises(self):
+        with self.assertRaises(ValueError):
+            await TestModel.async_objects.all().abulk_update(
+                [self.item1], ["value"], batch_size=0
+            )
+
+    async def test_object_without_pk_raises(self):
+        unsaved = TestModel(name="Unsaved", value=1)
+        with self.assertRaises(ValueError):
+            await TestModel.async_objects.all().abulk_update(
+                [unsaved], ["value"]
+            )
+
+    async def test_pk_field_raises(self):
+        with self.assertRaises(ValueError):
+            await TestModel.async_objects.all().abulk_update(
+                [self.item1], ["id"]
+            )
+
+
+class TestABulkUpdateRollback(AsyncioTransactionTestCase):
+    # AsyncioTransactionTestCase commits for real (it does not wrap the test
+    # in a rolled-back transaction), so the atomic block abulk_update opens
+    # is the outermost transaction and its rollback is observable.
+
+    async def asyncSetUp(self):
+        self.item1 = await TestModel.async_objects.acreate(
+            name="Item1", value=1
+        )
+        self.item2 = await TestModel.async_objects.acreate(
+            name="Item2", value=2
+        )
+        self.item3 = await TestModel.async_objects.acreate(
+            name="Item3", value=3
+        )
+
+    async def asyncTearDown(self):
+        async with await async_connections[
+            DEFAULT_DB_ALIAS
+        ].cursor() as cursor:
+            await cursor.execute("DELETE FROM test_model;")
+
+    async def test_failed_batch_rolls_back_earlier_batches(self):
+        # batch_size=1 turns each object into its own UPDATE inside one
+        # atomic block. The third rename collides with the first one's new
+        # unique name, so its batch raises -- the atomic must then roll back
+        # the two already-applied batches.
+        self.item1.name = "rollback-A"
+        self.item2.name = "rollback-B"
+        self.item3.name = "rollback-A"
+        with self.assertRaises(IntegrityError):
+            await TestModel.async_objects.all().abulk_update(
+                [self.item1, self.item2, self.item3], ["name"], batch_size=1
+            )
+        names = sorted(
+            [obj.name async for obj in TestModel.async_objects.all()]
+        )
+        self.assertEqual(names, ["Item1", "Item2", "Item3"])

--- a/tests/db/models/query/test_abulk_update.py
+++ b/tests/db/models/query/test_abulk_update.py
@@ -1,6 +1,12 @@
-from django.db import DEFAULT_DB_ALIAS, IntegrityError
+from django.db import (
+    DEFAULT_DB_ALIAS,
+    IntegrityError,
+)
 from django.db.models import F
-from test_app.models import TestModel
+from test_app.models import (
+    ChildModel,
+    TestModel,
+)
 
 from django_async_backend.db import async_connections
 from django_async_backend.test import (
@@ -188,6 +194,17 @@ class TestABulkUpdateValidation(AsyncioTestCase):
             await TestModel.async_objects.all().abulk_update(
                 [self.item1], ["id"]
             )
+
+    async def test_non_concrete_field_raises(self):
+        with self.assertRaises(ValueError):
+            await TestModel.async_objects.all().abulk_update(
+                [self.item1], ["relatives"]
+            )
+
+    async def test_parent_pk_field_raises(self):
+        child = await ChildModel.async_objects.acreate(child_value=1)
+        with self.assertRaises(ValueError):
+            await ChildModel.async_objects.all().abulk_update([child], ["id"])
 
 
 class TestABulkUpdateRollback(AsyncioTransactionTestCase):


### PR DESCRIPTION
abulk_update seemed sensible to add after abulk_create. Closes #36. Manually tested with glitchtip-backend codebase.

## LLM summary:

Generates async `abulk_update` from Django 6.0's sync `bulk_update` via codemon, following the `abulk_create` pattern from #41.

`bulk_update` ends in `queryset.filter(pk__in=pks).update(**kwargs)` inside one `transaction.atomic`, so the transform reuses the existing `aupdate` path — no new query class and no compiler change:

- `connections[self.db]` → `async_connections[self.db]` via the `renames` directive (same as the review fix on #41)
- `with transaction.atomic(...)` → `async with async_atomic(...)`
- `.update(**update_kwargs)` → `await ....aupdate(**update_kwargs)`
- `bulk_update.alters_data = True` preserved via assign rename

One codemon detail: `bulk_update` contains two `.update(` calls — the DB write and a plain `set.update()` on the parent pk-fields loop. Since the calls matcher stops at the first matching config entry, a no-op guard entry matching `all_pk_fields.update` first keeps the set call untouched.

Tests cover row count, multi-field updates, F() expressions, FK fields, duplicate pks, even/uneven batching, queryset filtering, empty objs, manager-level exposure, validation errors, and rollback of earlier batches when a later batch fails (via `AsyncioTransactionTestCase`).

## Summary by Sourcery

Add an async `abulk_update` queryset method mirroring Django's `bulk_update`, expose it via codemon config, and document its availability.

New Features:
- Introduce `abulk_update` for async bulk field updates on querysets and managers.

Enhancements:
- Configure codemon to generate the async `abulk_update` implementation from the existing sync `bulk_update` logic, including async connections and atomic context handling.

Documentation:
- Update README feature matrix to mark `Model.objects.abulk_update` as implemented.

Tests:
- Add comprehensive async tests for `abulk_update`, covering batching behavior, multiple fields, F() expressions, foreign keys, queryset filtering, validation errors, and transactional rollback semantics.