### PR TITLE
added docs about only + defer

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,8 @@ async def main():
 | `Model.objects.distinct`            | ✅        |          |
 | `Model.objects.extra`               | ✅        |          |
 | `Model.objects.reverse`             | ✅        |          |
-| `Model.objects.defer`               | ❌        |          |
-| `Model.objects.only`                | ❌        |          |
+| `Model.objects.defer`               | ⚠️        | not safe for async, will not be implemented — use `values`/`values_list` |
+| `Model.objects.only`                | ⚠️        | not safe for async, will not be implemented — use `values`/`values_list` |
 | `Model.objects.using`               | ✅        |          |
 | `Model.objects.resolve_expression`  | ❌        |          |
 | `Model.objects.ordered`             | ❌        |          |


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Document that `Model.objects.defer` and `Model.objects.only` are not safe for async use and recommend `values`/`values_list` as alternatives.