### PR TITLE
removed doc strings

### DIFF
--- a/codemon/__main__.py
+++ b/codemon/__main__.py
@@ -914,6 +914,86 @@ def class_transformer(name: str, config: Class) -> cst.CSTTransformer:
     return ClassTransformed()
 
 
+DOCSTRING_LINE = m.SimpleStatementLine(
+    body=[m.Expr(value=m.SimpleString()), m.ZeroOrMore()]
+)
+
+STATEMENT = (
+    m.SimpleStatementLine()
+    | m.ClassDef()
+    | m.For()
+    | m.FunctionDef()
+    | m.If()
+    | m.Match()
+    | m.Try()
+    | m.TryStar()
+    | m.While()
+    | m.With()
+)
+
+
+HAS_DOCSTRING = m.FunctionDef(
+    body=m.IndentedBlock(body=[DOCSTRING_LINE, m.ZeroOrMore()])
+) | m.ClassDef(body=m.IndentedBlock(body=[DOCSTRING_LINE, m.ZeroOrMore()]))
+
+
+def docstring_transformer() -> cst.CSTTransformer:
+    """Drop every docstring."""
+
+    def inherit_leading_lines(body: list, docstring) -> list:
+        if not body or not m.matches(body[0], STATEMENT):
+            return body
+
+        return [
+            body[0].with_changes(
+                leading_lines=[
+                    *docstring.leading_lines,
+                    *body[0].leading_lines,
+                ]
+            ),
+            *body[1:],
+        ]
+
+    class DocstringRemover(m.MatcherDecoratableTransformer):
+        def _strip(self, updated_node):
+            if not m.matches(updated_node, HAS_DOCSTRING):
+                return updated_node
+
+            block = updated_node.body
+            body = inherit_leading_lines(list(block.body[1:]), block.body[0])
+
+            if not body:
+                body = [cst.SimpleStatementLine(body=[cst.Pass()])]
+
+            return updated_node.with_changes(
+                body=block.with_changes(body=body)
+            )
+
+        def leave_FunctionDef(
+            self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+        ) -> cst.FunctionDef:
+            return self._strip(updated_node)
+
+        def leave_ClassDef(
+            self, original_node: cst.ClassDef, updated_node: cst.ClassDef
+        ) -> cst.ClassDef:
+            return self._strip(updated_node)
+
+        def leave_Module(
+            self, original_node: cst.Module, updated_node: cst.Module
+        ) -> cst.Module:
+            body = list(updated_node.body)
+
+            if not body or not m.matches(body[0], DOCSTRING_LINE):
+                return updated_node
+
+            return updated_node.with_changes(
+                body=inherit_leading_lines(body[1:], body[0])
+            )
+
+    return DocstringRemover()
+
+
 def module_transformer(config: Module) -> cst.CSTTransformer:
     class ModuleTransformed(m.MatcherDecoratableTransformer):
 
@@ -1090,5 +1170,6 @@ if __name__ == "__main__":
         ast = get_ast(config=config)
 
         ast = ast.visit(module_transformer(config.module))
+        ast = ast.visit(docstring_transformer())
 
         write_ast(ast, config=config, version=DJANGO_VERSION)

--- a/django_async_backend/db/models/base.py
+++ b/django_async_backend/db/models/base.py
@@ -131,14 +131,6 @@ class AsyncModelMixin:
         using=None,
         update_fields=None,
     ):
-        """
-        Save the current instance. Override this in a subclass if you want to
-        control the saving process.
-
-        The 'force_insert' and 'force_update' parameters can be used to insist
-        that the "save" must be an SQL insert or update (or equivalent for
-        non-SQL backends), respectively. Normally, they should not be set.
-        """
 
         await self._async_prepare_related_fields_for_save(
             operation_name="save"
@@ -229,15 +221,6 @@ class AsyncModelMixin:
         using=None,
         update_fields=None,
     ):
-        """
-        Handle the parts of saving which should be done only once per save,
-        yet need to be done in raw saves, too. This includes some sanity
-        checks and signal sending.
-
-        The 'raw' argument is telling save_base not to save any parent
-        models and not to do any changes to the values before save. This
-        is used by fixture loading.
-        """
         using = using or router.db_for_write(self.__class__, instance=self)
         assert not (force_insert and (force_update or update_fields))
         assert update_fields is None or update_fields
@@ -296,7 +279,6 @@ class AsyncModelMixin:
     async def _async_save_parents(
         self, cls, using, update_fields, force_insert, updated_parents=None
     ):
-        """Save all the parents of cls using values from self."""
         meta = cls._meta
         inserted = False
         if updated_parents is None:
@@ -354,10 +336,6 @@ class AsyncModelMixin:
         using=None,
         update_fields=None,
     ):
-        """
-        Do the heavy-lifting involved in saving. Update or insert the data
-        for a single table.
-        """
         meta = cls._meta
         pk_fields = meta.pk_fields
         non_pks_non_generated = [
@@ -511,11 +489,6 @@ class AsyncModelMixin:
         forced_update,
         returning_fields,
     ):
-        """
-        Try to update the model. Return a list of updated fields if the model
-        was updated (if an update query was done and a matching row was
-        found in the DB).
-        """
         filtered = base_qs.filter(pk=pk_val)
         if not values:
             # We can end up here when saving a model in inheritance chain where
@@ -544,10 +517,6 @@ class AsyncModelMixin:
     async def _async_do_insert(
         self, manager, using, fields, returning_fields, raw
     ):
-        """
-        Do an INSERT. If returning_fields is defined then this method should
-        return the newly created data for the model.
-        """
         return await manager._insert(
             [self],
             fields=fields,

--- a/django_async_backend/db/models/deletion.py
+++ b/django_async_backend/db/models/deletion.py
@@ -148,13 +148,6 @@ class Collector:
         self.dependencies = defaultdict(set)  # {model: {models}}
 
     def add(self, objs, source=None, nullable=False, reverse_dependency=False):
-        """
-        Add 'objs' to the collection of objects to be deleted. If the call is
-        the result of a cascade, 'source' should be the model that caused it,
-        and 'nullable' should be set to True if the relation can be null.
-
-        Return a list of all objects that were not already collected.
-        """
         if not objs:
             return []
         new_objs = []
@@ -182,10 +175,6 @@ class Collector:
         self.data.setdefault(dependency, self.data.default_factory())
 
     def add_field_update(self, field, value, objs):
-        """
-        Schedule a field update. 'objs' must be a homogeneous iterable
-        collection of model instances (e.g. a QuerySet).
-        """
         self.field_updates[field, value].append(objs)
 
     def add_restricted_objects(self, field, objs):
@@ -222,16 +211,6 @@ class Collector:
         ) or signals.post_delete.has_listeners(model)
 
     def can_fast_delete(self, objs, from_field=None):
-        """
-        Determine if the objects in the given queryset-like or single object
-        can be fast-deleted. This can be done if there are no cascades, no
-        parents and no signal listeners for the object class.
-
-        The 'from_field' tells where we are coming from - we need this to
-        determine if the objects are in fact to be deleted. Allow also
-        skipping parent -> child -> parent chain preventing fast delete of
-        the child.
-        """
         if self.force_collection:
             return False
         if (
@@ -271,9 +250,6 @@ class Collector:
         )
 
     def get_del_batches(self, objs, fields):
-        """
-        Return the objs in suitably sized batches for the used connection.
-        """
         conn_batch_size = max(
             async_connections[self.using].ops.bulk_batch_size(fields, objs), 1
         )
@@ -296,29 +272,6 @@ class Collector:
         keep_parents=False,
         fail_on_restricted=True,
     ):
-        """
-        Add 'objs' to the collection of objects to be deleted as well as all
-        parent instances. 'objs' must be a homogeneous iterable collection of
-        model instances (e.g. a QuerySet). If 'collect_related' is True,
-        related objects will be handled by their respective on_delete handler.
-
-        If the call is the result of a cascade, 'source' should be the model
-        that caused it and 'nullable' should be set to True, if the relation
-        can be null.
-
-        If 'reverse_dependency' is True, 'source' will be deleted before the
-        current model, rather than after. (Needed for cascading to parent
-        models, the one case in which the cascade follows the forwards
-        direction of an FK rather than the reverse direction.)
-
-        If 'keep_parents' is True, data of parent model's will be not deleted.
-
-        If 'fail_on_restricted' is False, error won't be raised even if it's
-        prohibited to delete such objects due to RESTRICT, that defers
-        restricted object checking in recursive calls where the top-level call
-        may need to collect more objects to determine whether restricted ones
-        can be deleted.
-        """
         if self.can_fast_delete(objs):
             self.fast_deletes.append(objs)
             return
@@ -481,9 +434,6 @@ class Collector:
                     )
 
     def related_objects(self, related_model, related_fields, objs):
-        """
-        Get a QuerySet of the related model to objs via related fields.
-        """
         predicate = query_utils.Q.create(
             [
                 (f"{related_field.name}__in", objs)
@@ -676,16 +626,6 @@ async def _abulk_related_objects(field, objs, using):
 
 
 def _parent_chain_fields(opts):
-    """Field names that must stay loaded on a multi-table inheritance
-    child so its parent instances can be built from data already in
-    memory.
-
-    ``collect()`` reads parent instances with ``getattr(obj, ptr.name)``.
-    Django's ``ForwardOneToOneDescriptor`` answers that from the child's
-    own columns, but only while none of the parent's concrete fields is
-    deferred -- otherwise it falls back to a query per object, which is
-    synchronous and blows up in an async context.
-    """
     return {
         field.name
         for ptr in opts.concrete_model._meta.parents.values()

--- a/django_async_backend/db/models/query.py
+++ b/django_async_backend/db/models/query.py
@@ -98,7 +98,6 @@ class BaseIterable:
 
 
 class ModelIterable(BaseIterable):
-    """Iterable that yields a model instance for each row."""
 
     async def __aiter__(self):
         queryset = self.queryset
@@ -189,9 +188,6 @@ class ModelIterable(BaseIterable):
 
 
 class RawModelIterable(BaseIterable):
-    """
-    Iterable that yields a model instance for each row from a raw queryset.
-    """
 
     async def __aiter__(self):
         # Cache some things for performance reasons outside the loop.
@@ -259,9 +255,6 @@ class RawModelIterable(BaseIterable):
 
 
 class ValuesIterable(BaseIterable):
-    """
-    Iterable returned by QuerySet.values() that yields a dict for each row.
-    """
 
     async def __aiter__(self):
         queryset = self.queryset
@@ -285,10 +278,6 @@ class ValuesIterable(BaseIterable):
 
 
 class ValuesListIterable(BaseIterable):
-    """
-    Iterable returned by QuerySet.values_list(flat=False) that yields a tuple
-    for each row.
-    """
 
     async def __aiter__(self):
         queryset = self.queryset
@@ -304,10 +293,6 @@ class ValuesListIterable(BaseIterable):
 
 
 class NamedValuesListIterable(ValuesListIterable):
-    """
-    Iterable returned by QuerySet.values_list(named=True) that yields a
-    namedtuple for each row.
-    """
 
     async def __aiter__(self):
         queryset = self.queryset
@@ -327,10 +312,6 @@ class NamedValuesListIterable(ValuesListIterable):
 
 
 class FlatValuesListIterable(BaseIterable):
-    """
-    Iterable returned by QuerySet.values_list(flat=True) that yields single
-    values.
-    """
 
     async def __aiter__(self):
         queryset = self.queryset
@@ -342,14 +323,6 @@ class FlatValuesListIterable(BaseIterable):
 
 
 class PreventQuerySetCloning:
-    """
-    Temporarily prevent the given QuerySet from creating new QuerySet instances
-    on each mutating operation (e.g: filter(), exclude() etc), instead
-    modifying the QuerySet in-place.
-
-    @contextlib.contextmanager is intentionally not used for performance
-    reasons.
-    """
 
     __slots__ = ("queryset",)
 
@@ -364,7 +337,6 @@ class PreventQuerySetCloning:
 
 
 class QuerySet(AltersData):
-    """Represent a lazy database lookup for a set of objects."""
     def __iter__(self):
         raise TypeError(
             f"{self.__class__.__name__} is not iterable synchronously. "
@@ -426,7 +398,6 @@ class QuerySet(AltersData):
     ########################
 
     def __deepcopy__(self, memo):
-        """Don't populate the QuerySet's cache."""
         obj = self.__class__()
         for k, v in self.__dict__.items():
             if k == "_result_cache":
@@ -446,7 +417,6 @@ class QuerySet(AltersData):
         return generator()
 
     def __getitem__(self, k):
-        """Retrieve an item or slice from the set of results."""
 
         async def fetch_data(query_set, index):
             if query_set._result_cache is None:
@@ -573,13 +543,6 @@ class QuerySet(AltersData):
         return combined
 
     async def aaggregate(self, *args, **kwargs):
-        """
-        Return a dictionary containing the calculations (aggregation)
-        over the current queryset.
-
-        If args is present the expression is passed as a kwarg using
-        the Aggregate object's default alias.
-        """
         if self.query.distinct_fields:
             raise NotImplementedError(
                 "aggregate() + distinct(fields) not implemented."
@@ -600,23 +563,12 @@ class QuerySet(AltersData):
         return await self.query.chain().get_aggregation(self.db, kwargs)
 
     async def acount(self):
-        """
-        Perform a SELECT COUNT() and return the number of records as an
-        integer.
-
-        If the QuerySet is already fully cached, return the length of the
-        cached results set to avoid multiple SELECT COUNT(*) calls.
-        """
         if self._result_cache is not None:
             return len(self._result_cache)
 
         return await self.query.get_count(using=self.db)
 
     async def aget(self, *args, **kwargs):
-        """
-        Perform the query and return a single object matching the given
-        keyword arguments.
-        """
         if self.query.combinator and (args or kwargs):
             raise NotSupportedError(
                 "Calling QuerySet.get(...) with filters after %s() is not "
@@ -659,10 +611,6 @@ class QuerySet(AltersData):
         )
 
     async def acreate(self, **kwargs):
-        """
-        Create a new object with the given kwargs, saving it to the database
-        and returning the created object.
-        """
         reverse_one_to_one_fields = frozenset(kwargs).intersection(
             self.model._meta._reverse_one_to_one_field_names
         )
@@ -767,14 +715,6 @@ class QuerySet(AltersData):
         update_fields=None,
         unique_fields=None,
     ):
-        """
-        Insert each of the instances into the database. Do *not* call
-        save() on each of the instances, do not send any pre/post_save
-        signals, and do not set the primary key attribute if it is an
-        autoincrement field (except if
-        features.can_return_rows_from_bulk_insert=True).
-        Multi-table models are not supported.
-        """
         # When you bulk insert you don't get the primary keys back (if it's an
         # autoincrement, except if can_return_rows_from_bulk_insert=True), so
         # you can't insert into the child tables which references this. There
@@ -922,9 +862,6 @@ class QuerySet(AltersData):
     abulk_create.alters_data = True
 
     async def abulk_update(self, objs, fields, batch_size=None):
-        """
-        Update the given fields in each of the given objects in the database.
-        """
         if batch_size is not None and batch_size <= 0:
             raise ValueError("Batch size must be a positive integer.")
         if not fields:
@@ -994,11 +931,6 @@ class QuerySet(AltersData):
     abulk_update.alters_data = True
 
     async def aget_or_create(self, defaults=None, **kwargs):
-        """
-        Look up an object with the given kwargs, creating one if necessary.
-        Return a tuple of (object, created), where created is a boolean
-        specifying whether an object was created.
-        """
         # The get() needs to be targeted at the write database in order
         # to avoid potential transaction consistency problems.
         self._for_write = True
@@ -1023,14 +955,6 @@ class QuerySet(AltersData):
     async def aupdate_or_create(
         self, defaults=None, create_defaults=None, **kwargs
     ):
-        """
-        Look up an object with the given kwargs, updating one with defaults
-        if it exists, otherwise create a new one. Optionally, an object can
-        be created with different values than defaults by using
-        create_defaults.
-        Return a tuple (object, created), where created is a boolean
-        specifying whether an object was created.
-        """
         update_defaults = defaults or {}
         if create_defaults is None:
             create_defaults = update_defaults
@@ -1076,10 +1000,6 @@ class QuerySet(AltersData):
     aupdate_or_create.alters_data = True
 
     def _extract_model_params(self, defaults, **kwargs):
-        """
-        Prepare `params` for creating a model instance based on the given
-        kwargs; for use by get_or_create().
-        """
         defaults = defaults or {}
         params = {k: v for k, v in kwargs.items() if LOOKUP_SEP not in k}
         params.update(defaults)
@@ -1105,10 +1025,6 @@ class QuerySet(AltersData):
         return params
 
     def _earliest(self, *fields):
-        """
-        Return the earliest object according to fields (if given) or by the
-        model's Meta.get_latest_by.
-        """
         if fields:
             order_by = fields
         else:
@@ -1134,10 +1050,6 @@ class QuerySet(AltersData):
         return self._earliest(*fields)
 
     def alatest(self, *fields):
-        """
-        Return the latest object according to fields (if given) or by the
-        model's Meta.get_latest_by.
-        """
         if self.query.is_sliced:
             raise TypeError(
                 "Cannot change a query once a slice has been taken."
@@ -1145,7 +1057,6 @@ class QuerySet(AltersData):
         return self.reverse()._earliest(*fields)
 
     async def afirst(self):
-        """Return the first object of a query or None if no match is found."""
         if self.ordered or not self.query.default_ordering:
             queryset = self
         else:
@@ -1157,7 +1068,6 @@ class QuerySet(AltersData):
             return obj
 
     async def alast(self):
-        """Return the last object of a query or None if no match is found."""
         if self.ordered or not self.query.default_ordering:
             queryset = self.reverse()
         else:
@@ -1167,10 +1077,6 @@ class QuerySet(AltersData):
             return obj
 
     async def ain_bulk(self, id_list=None, *, field_name="pk"):
-        """
-        Return a dictionary mapping each of the given IDs to the object with
-        that ID. If `id_list` isn't provided, evaluate the entire QuerySet.
-        """
         if self.query.is_sliced:
             raise TypeError("Cannot use 'limit' or 'offset' with in_bulk().")
         if id_list is not None and not id_list:
@@ -1273,7 +1179,6 @@ class QuerySet(AltersData):
         )
 
     async def adelete(self):
-        """Delete the records in the current QuerySet."""
 
         from django_async_backend.db.models.deletion import Collector
 
@@ -1311,10 +1216,6 @@ class QuerySet(AltersData):
     adelete.queryset_only = True
 
     async def _raw_delete(self, using):
-        """
-        Delete objects found from the given queryset in single direct SQL
-        query. No signals are sent and there is no protection for cascades.
-        """
         query = self.query.clone()
         query.__class__ = async_sql.DeleteQuery
         return await query.get_compiler(using).execute_sql(ROW_COUNT)
@@ -1322,10 +1223,6 @@ class QuerySet(AltersData):
     _raw_delete.alters_data = True
 
     async def aupdate(self, **kwargs):
-        """
-        Update all elements in the current QuerySet, setting all the given
-        fields to the appropriate values.
-        """
         self._not_support_combined_queries("update")
         if self.query.is_sliced:
             raise TypeError(
@@ -1368,12 +1265,6 @@ class QuerySet(AltersData):
     aupdate.alters_data = True
 
     async def _update(self, values, returning_fields=None):
-        """
-        A version of update() that accepts field objects instead of field
-        names. Used primarily for model saving and not intended for use by
-        general code (it requires too much poking around at model internals to
-        be useful at that level).
-        """
         if self.query.is_sliced:
             raise TypeError(
                 "Cannot update a query once a slice has been taken."
@@ -1393,18 +1284,11 @@ class QuerySet(AltersData):
     _update.queryset_only = False
 
     async def aexists(self):
-        """
-        Return True if the QuerySet would have any results, False otherwise.
-        """
         if self._result_cache is None:
             return await self.query.has_results(using=self.db)
         return bool(self._result_cache)
 
     async def acontains(self, obj):
-        """
-        Return True if the QuerySet contains the provided obj,
-        False otherwise.
-        """
         self._not_support_combined_queries("contains")
         if self._fields is not None:
             raise TypeError(
@@ -1431,10 +1315,6 @@ class QuerySet(AltersData):
         self._prefetch_done = True
 
     async def aexplain(self, *, format=None, **options):
-        """
-        Runs an EXPLAIN on the SQL query this QuerySet would perform, and
-        returns the results.
-        """
         return await self.query.explain(
             using=self.db, format=format, **options
         )
@@ -1523,10 +1403,6 @@ class QuerySet(AltersData):
         return clone
 
     def dates(self, field_name, kind, order="ASC"):
-        """
-        Return a list of date objects representing all available dates for
-        the given field_name, scoped to 'kind'.
-        """
         if kind not in ("year", "month", "week", "day"):
             raise ValueError(
                 "'kind' must be one of 'year', 'month', 'week', or 'day'."
@@ -1545,10 +1421,6 @@ class QuerySet(AltersData):
         )
 
     def datetimes(self, field_name, kind, order="ASC", tzinfo=None):
-        """
-        Return a list of datetime objects representing all available
-        datetimes for the given field_name, scoped to 'kind'.
-        """
         if kind not in (
             "year",
             "month",
@@ -1586,7 +1458,6 @@ class QuerySet(AltersData):
         )
 
     def none(self):
-        """Return an empty QuerySet."""
         clone = self._chain()
         clone.query.set_empty()
         return clone
@@ -1596,25 +1467,13 @@ class QuerySet(AltersData):
     ##################################################################
 
     def all(self):
-        """
-        Return a new QuerySet that is a copy of the current one. This allows a
-        QuerySet to proxy for a model manager in some cases.
-        """
         return self._chain()
 
     def filter(self, *args, **kwargs):
-        """
-        Return a new QuerySet instance with the args ANDed to the existing
-        set.
-        """
         self._not_support_combined_queries("filter")
         return self._filter_or_exclude(False, args, kwargs)
 
     def exclude(self, *args, **kwargs):
-        """
-        Return a new QuerySet instance with NOT (args) ANDed to the existing
-        set.
-        """
         self._not_support_combined_queries("exclude")
         return self._filter_or_exclude(True, args, kwargs)
 
@@ -1645,15 +1504,6 @@ class QuerySet(AltersData):
             self._query.add_q(Q(*args, **kwargs))
 
     def complex_filter(self, filter_obj):
-        """
-        Return a new QuerySet instance with filter_obj added to the filters.
-
-        filter_obj can be a Q object or a dictionary of keyword lookup
-        arguments.
-
-        This exists to support framework features such as 'limit_choices_to',
-        and usually it will be more natural to use other methods.
-        """
         if isinstance(filter_obj, Q):
             clone = self._chain()
             clone.query.add_q(filter_obj)
@@ -1704,10 +1554,6 @@ class QuerySet(AltersData):
     def select_for_update(
         self, nowait=False, skip_locked=False, of=(), no_key=False
     ):
-        """
-        Return a new QuerySet instance that will select objects with a
-        FOR UPDATE lock.
-        """
         if nowait and skip_locked:
             raise ValueError(
                 "The nowait option cannot be used with skip_locked."
@@ -1722,14 +1568,6 @@ class QuerySet(AltersData):
         return obj
 
     def select_related(self, *fields):
-        """
-        Return a new QuerySet instance that will select related objects.
-
-        If fields are specified, they must be ForeignKey fields and only those
-        related objects are included in the selection.
-
-        If select_related(None) is called, clear the list.
-        """
         self._not_support_combined_queries("select_related")
         if self._fields is not None:
             raise TypeError(
@@ -1754,17 +1592,10 @@ class QuerySet(AltersData):
         return obj
 
     def annotate(self, *args, **kwargs):
-        """
-        Return a query set in which the returned objects have been annotated
-        with extra data or aggregations.
-        """
         self._not_support_combined_queries("annotate")
         return self._annotate(args, kwargs, select=True)
 
     def alias(self, *args, **kwargs):
-        """
-        Return a query set with added aliases for extra data or aggregations.
-        """
         self._not_support_combined_queries("alias")
         return self._annotate(args, kwargs, select=False)
 
@@ -1828,7 +1659,6 @@ class QuerySet(AltersData):
         return clone
 
     def order_by(self, *field_names):
-        """Return a new QuerySet instance with the ordering changed."""
         if self.query.is_sliced:
             raise TypeError(
                 "Cannot reorder a query once a slice has been taken."
@@ -1839,9 +1669,6 @@ class QuerySet(AltersData):
         return obj
 
     def distinct(self, *field_names):
-        """
-        Return a new QuerySet instance that will select only distinct results.
-        """
         self._not_support_combined_queries("distinct")
         if self.query.is_sliced:
             raise TypeError(
@@ -1860,7 +1687,6 @@ class QuerySet(AltersData):
         order_by=None,
         select_params=None,
     ):
-        """Add extra SQL fragments to the query."""
         self._not_support_combined_queries("extra")
         if self.query.is_sliced:
             raise TypeError(
@@ -1873,7 +1699,6 @@ class QuerySet(AltersData):
         return clone
 
     def reverse(self):
-        """Reverse the ordering of the QuerySet."""
         if self.query.is_sliced:
             raise TypeError(
                 "Cannot reverse a query once a slice has been taken."
@@ -1883,11 +1708,6 @@ class QuerySet(AltersData):
         return clone
 
     def _only(self, *fields):
-        """
-        Essentially, the opposite of defer(). Only the fields passed into this
-        method and that are not already specified as deferred are loaded
-        immediately when the queryset is evaluated.
-        """
         self._not_support_combined_queries("only")
         if self._fields is not None:
             raise TypeError(
@@ -1908,13 +1728,11 @@ class QuerySet(AltersData):
         return clone
 
     def using(self, alias):
-        """Select which database this QuerySet should execute against."""
         clone = self._chain()
         clone._db = alias
         return clone
 
     def fetch_mode(self, fetch_mode):
-        """Set the fetch mode for the QuerySet."""
         clone = self._chain()
         clone._fetch_mode = fetch_mode
         return clone
@@ -1925,10 +1743,6 @@ class QuerySet(AltersData):
 
     @property
     def ordered(self):
-        """
-        Return True if the QuerySet is ordered -- i.e. has an order_by()
-        clause or a default ordering on the model (or is empty).
-        """
         if isinstance(self, EmptyQuerySet):
             return True
         if self.query.extra_order_by or self.query.order_by:
@@ -1946,15 +1760,6 @@ class QuerySet(AltersData):
 
     @property
     def totally_ordered(self):
-        """
-        Returns True if the QuerySet is ordered and the ordering is
-        deterministic. This requires that the ordering includes a field
-        (or set of fields) that is unique and non-nullable.
-
-        For queries involving a GROUP BY clause, the model's default
-        ordering is ignored. Ordering specified via .extra(order_by=...)
-        is also ignored.
-        """
         if not self.ordered:
             return False
         ordering = self.query.order_by
@@ -2025,7 +1830,6 @@ class QuerySet(AltersData):
 
     @property
     def db(self):
-        """Return the database used if this query is executed now."""
         if self._for_write:
             return self._db or router.db_for_write(self.model, **self._hints)
         return self._db or router.db_for_read(self.model, **self._hints)
@@ -2045,10 +1849,6 @@ class QuerySet(AltersData):
         update_fields=None,
         unique_fields=None,
     ):
-        """
-        Insert a new record for the given model. This provides an interface to
-        the InsertQuery class and is how Model.save() is implemented.
-        """
         self._for_write = True
         if using is None:
             using = self.db
@@ -2075,9 +1875,6 @@ class QuerySet(AltersData):
         update_fields=None,
         unique_fields=None,
     ):
-        """
-        Helper method for bulk_create() to insert objs one batch at a time.
-        """
         connection = connections[self.db]
         ops = connection.ops
         max_batch_size = max(ops.bulk_batch_size(fields, objs), 1)
@@ -2116,45 +1913,17 @@ class QuerySet(AltersData):
         return inserted_rows
 
     def _disable_cloning(self):
-        """
-        Prevent calls to _chain() from creating a new QuerySet via _clone().
-        All subsequent QuerySet mutations will occur on this instance until
-        _enable_cloning() is used.
-        """
         self._cloning_enabled = False
         return self
 
     def _enable_cloning(self):
-        """
-        Allow calls to _chain() to create a new QuerySet via _clone(). Restores
-        the default behavior where any QuerySet mutation will return a new
-        QuerySet instance. Necessary only when there has been a
-        _disable_cloning() call previously.
-        """
         self._cloning_enabled = True
         return self
 
     def _avoid_cloning(self):
-        """
-        Temporarily prevent QuerySet _clone() operations, restoring the default
-        behavior on exit. For the duration of the context managed statement,
-        all operations (e.g. filter(), exclude(), etc.) will mutate the same
-        QuerySet instance.
-
-        @contextlib.contextmanager is intentionally not used for performance
-        reasons.
-        """
         return PreventQuerySetCloning(self)
 
     def _chain(self):
-        """
-        Return a copy of the current QuerySet that's ready for another
-        operation.
-
-        If the QuerySet has opted in to in-place mutations via
-        _disable_cloning() temporarily, the copy doesn't occur and instead the
-        same QuerySet instance will be modified.
-        """
         if not self._cloning_enabled:
             obj = self
         else:
@@ -2165,10 +1934,6 @@ class QuerySet(AltersData):
         return obj
 
     def _clone(self):
-        """
-        Return a copy of the current QuerySet. A lightweight alternative
-        to deepcopy().
-        """
         c = self.__class__(
             model=self.model,
             query=self.query.chain(),
@@ -2193,21 +1958,10 @@ class QuerySet(AltersData):
             await self._prefetch_related_objects()
 
     def _next_is_sticky(self):
-        """
-        Indicate that the next filter call and the one following that should
-        be treated as a single filter. This is only important when it comes to
-        determining when to reuse tables for many-to-many filters. Required so
-        that we can filter naturally on the results of related managers.
-
-        This doesn't return a clone of the current QuerySet (it returns
-        "self"). The method is only used internally and should be immediately
-        followed by a filter() that does create a clone.
-        """
         self._sticky_filter = True
         return self
 
     def _merge_sanity_check(self, other):
-        """Check that two QuerySet classes may be merged."""
         if self._fields is not None and (
             set(self.query.values_select) != set(other.query.values_select)
             or set(self.query.extra_select) != set(other.query.extra_select)
@@ -2220,9 +1974,6 @@ class QuerySet(AltersData):
             )
 
     def _merge_known_related_objects(self, other):
-        """
-        Keep track of all known related objects from either QuerySet instance.
-        """
         for field, objects in other._known_related_objects.items():
             self._known_related_objects.setdefault(field, {}).update(objects)
 
@@ -2234,18 +1985,9 @@ class QuerySet(AltersData):
     resolve_expression.queryset_only = True
 
     def _add_hints(self, **hints):
-        """
-        Update hinting information for use by routers. Add new key/values or
-        overwrite existing key/values.
-        """
         self._hints.update(hints)
 
     def _has_filters(self):
-        """
-        Check if this QuerySet has any filtering going on. This isn't
-        equivalent with checking if all objects are present in results, for
-        example, qs[1:]._has_filters() -> False.
-        """
         return self.query.has_filters()
 
     @staticmethod
@@ -2314,20 +2056,12 @@ class InstanceCheckMeta(type):
 
 
 class EmptyQuerySet(metaclass=InstanceCheckMeta):
-    """
-    Marker class to checking if a queryset is empty by .none():
-        isinstance(qs.none(), EmptyQuerySet) -> True
-    """
 
     def __init__(self, *args, **kwargs):
         raise TypeError("EmptyQuerySet can't be instantiated")
 
 
 class RawQuerySet:
-    """
-    Provide an iterator which converts the results of raw SQL queries into
-    annotated model instances.
-    """
 
     def __init__(
         self,
@@ -2355,7 +2089,6 @@ class RawQuerySet:
         self._fetch_mode = fetch_mode
 
     def resolve_model_init_order(self):
-        """Resolve the init field names and value positions."""
         converter = connections[self.db].introspection.identifier_converter
         model_init_fields = [
             field
@@ -2374,7 +2107,6 @@ class RawQuerySet:
         return model_init_names, model_init_order, annotation_fields
 
     def prefetch_related(self, *lookups):
-        """Same as QuerySet.prefetch_related()"""
         clone = self._clone()
         if lookups == (None,):
             clone._prefetch_related_lookups = ()
@@ -2391,7 +2123,6 @@ class RawQuerySet:
         self._prefetch_done = True
 
     def _clone(self):
-        """Same as QuerySet._clone()"""
         c = self.__class__(
             self.raw_query,
             model=self.model,
@@ -2443,11 +2174,9 @@ class RawQuerySet:
 
     @property
     def db(self):
-        """Return the database used if this query is executed now."""
         return self._db or router.db_for_read(self.model, **self._hints)
 
     def using(self, alias):
-        """Select the database this RawQuerySet should execute against."""
         return RawQuerySet(
             self.raw_query,
             model=self.model,
@@ -2460,10 +2189,6 @@ class RawQuerySet:
 
     @cached_property
     def columns(self):
-        """
-        A list of model field names in the order they'll appear in the
-        query results.
-        """
         columns = self.query.get_columns()
         # Adjust any column names which don't match field names
         for query_name, model_name in self.translations.items():
@@ -2478,7 +2203,6 @@ class RawQuerySet:
 
     @cached_property
     def model_fields(self):
-        """A dict mapping column names to model field names."""
         converter = connections[self.db].introspection.identifier_converter
         return {
             converter(field.column): field
@@ -2554,7 +2278,6 @@ class Prefetch:
 
 
 def normalize_prefetch_lookups(lookups, prefix=None):
-    """Normalize lookups into Prefetch objects."""
     ret = []
     for lookup in lookups:
         if not isinstance(lookup, Prefetch):
@@ -2566,10 +2289,6 @@ def normalize_prefetch_lookups(lookups, prefix=None):
 
 
 async def prefetch_related_objects(model_instances, *related_lookups):
-    """
-    Populate prefetched object caches for an iterable of model instances based
-    on the lookups/Prefetch instances given.
-    """
     if not model_instances:
         return  # nothing to do
 
@@ -2726,23 +2445,12 @@ async def prefetch_related_objects(model_instances, *related_lookups):
 
 
 async def aprefetch_related_objects(model_instances, *related_lookups):
-    """See prefetch_related_objects()."""
     return await sync_to_async(prefetch_related_objects)(
         model_instances, *related_lookups
     )
 
 
 def get_prefetcher(instance, through_attr, to_attr):
-    """
-    For the attribute 'through_attr' on the given instance, find
-    an object that has a get_prefetch_querysets().
-    Return a 4 tuple containing:
-    (the object with get_prefetch_querysets (or None),
-     the descriptor object representing this relationship (or None),
-     a boolean that is False if the attribute was not found at all,
-     a function that takes an instance and returns a boolean that is True if
-     the attribute has already been fetched for that instance)
-    """
 
     def is_to_attr_fetched(model, to_attr):
         # Special case cached_property instances because hasattr() triggers
@@ -2800,15 +2508,6 @@ def get_prefetcher(instance, through_attr, to_attr):
 
 
 def prefetch_one_level(instances, prefetcher, lookup, level):
-    """
-    Helper function for prefetch_related_objects().
-
-    Run prefetches on all instances using the prefetcher object,
-    assigning results to relevant caches in instance.
-
-    Return the prefetched objects along with any additional prefetches that
-    must be done due to prefetch_related lookups found from default managers.
-    """
     # prefetcher must have a method get_prefetch_querysets() which takes a list
     # of instances, and returns a tuple:
 
@@ -2912,20 +2611,6 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
 
 
 class RelatedPopulator:
-    """
-    RelatedPopulator is used for select_related() object instantiation.
-
-    The idea is that each select_related() model will be populated by a
-    different RelatedPopulator instance. The RelatedPopulator instances get
-    klass_info and select (computed in SQLCompiler) plus the used db as
-    input for initialization. That data is used to compute which columns
-    to use, how to instantiate the model, and how to populate the links
-    between the objects.
-
-    The actual creation of the objects is done in populate() method. This
-    method gets row and from_obj as input and populates the select_related()
-    model instance.
-    """
 
     def __init__(self, klass_info, select, db, fetch_mode):
         self.db = db

--- a/django_async_backend/db/models/sql/compiler.py
+++ b/django_async_backend/db/models/sql/compiler.py
@@ -111,11 +111,6 @@ class SQLCompiler:
         self.col_count = len(self.select)
 
     def pre_sql_setup(self, with_col_aliases=False):
-        """
-        Do any necessary class setup immediately prior to producing SQL. This
-        is for things that can't necessarily be done in __init__ because we
-        might not have all the pieces in place at that time.
-        """
         self.setup_query(with_col_aliases=with_col_aliases)
         order_by = self.get_order_by()
         self.where, self.having, self.qualify = (
@@ -129,13 +124,6 @@ class SQLCompiler:
         return extra_select, order_by, group_by
 
     def get_group_by(self, select, order_by):
-        """
-        Return a list of 2-tuples of form (sql, params).
-
-        The logic of what exactly the GROUP BY clause contains is hard
-        to describe in other words than "if it passes the test suite,
-        then it is correct".
-        """
         # Some examples:
         #     SomeModel.objects.annotate(Count('somecol'))
         #     GROUP BY: all fields of the model
@@ -275,23 +263,6 @@ class SQLCompiler:
             cls.get_select_from_parent(ki)
 
     def get_select(self, with_col_aliases=False):
-        """
-        Return three values:
-        - a list of 3-tuples of (expression, (sql, params), alias)
-        - a klass_info structure,
-        - a dictionary of annotations
-
-        The (sql, params) is what the expression will produce, and alias is the
-        "AS alias" for the column (possibly None).
-
-        The klass_info structure contains the following information:
-        - The base model of the query.
-        - Which columns for that model are present in the query (by
-          position of the select clause).
-        - related_klass_infos: [f, klass_info] to descent into
-
-        The annotations is a dictionary of {'attname': column position} values.
-        """
         select = []
         klass_info = None
         annotations = {}
@@ -532,14 +503,6 @@ class SQLCompiler:
                     )
 
     def get_order_by(self):
-        """
-        Return a list of 2-tuples of the form (expr, (sql, params, is_ref)) for
-        the ORDER BY clause.
-
-        The order_by clause can alter the select clause (for example it can add
-        aliases to clauses that do not yet have one, or it can add totally new
-        select clauses).
-        """
         result = []
         seen = set()
         for expr, is_ref in self._order_by_pairs():
@@ -617,10 +580,6 @@ class SQLCompiler:
         return extra_select
 
     def quote_name(self, name):
-        """
-        A wrapper around connection.ops.quote_name that memoizes quoted
-        name values.
-        """
         if (quoted := self.quote_cache.get(name)) is not None:
             return quoted
         quoted = self.connection.ops.quote_name(name)
@@ -842,13 +801,6 @@ class SQLCompiler:
         return result, params
 
     def as_sql(self, with_limits=True, with_col_aliases=False):
-        """
-        Create the SQL for this query. Return the SQL string and list of
-        parameters.
-
-        If 'with_limits' is False, any limit/offset information is not included
-        in the query.
-        """
         refcounts_before = self.query.alias_refcount.copy()
         try:
             combinator = self.query.combinator
@@ -1091,17 +1043,6 @@ class SQLCompiler:
     def get_default_columns(
         self, select_mask, start_alias=None, opts=None, from_parent=None
     ):
-        """
-        Compute the default columns for selecting every field in the base
-        model. Will sometimes be called to pull in related models (e.g. via
-        select_related), in which case "opts" and "start_alias" will be given
-        to provide a starting point for the traversal.
-
-        Return a list of strings, quoted appropriately for use in SQL
-        directly, as well as a set of aliases used in the select statement (if
-        'as_pairs' is True, return a list of (alias, col_name) pairs instead
-        of strings as the first component and None as the second component).
-        """
         result = []
         if opts is None:
             if (opts := self.query.get_meta()) is None:
@@ -1143,12 +1084,6 @@ class SQLCompiler:
         return result
 
     def get_distinct(self):
-        """
-        Return a quoted list of fields to use in DISTINCT ON part of the query.
-
-        This method can alter the tables in the query, and thus it must be
-        called before get_from_clause().
-        """
         result = []
         params = []
         opts = self.query.get_meta()
@@ -1171,11 +1106,6 @@ class SQLCompiler:
     def find_ordering_name(
         self, name, opts, alias=None, default_order="ASC", already_seen=None
     ):
-        """
-        Return the table alias (the name might be ambiguous, the alias will
-        not be) and column name for ordering by the given 'name' parameter.
-        The 'name' is of the form 'field1__field2__...__fieldN'.
-        """
         name, order = get_order_dir(name, default_order)
         descending = order == "DESC"
         pieces = name.split(LOOKUP_SEP)
@@ -1238,13 +1168,6 @@ class SQLCompiler:
         ]
 
     def _setup_joins(self, pieces, opts, alias):
-        """
-        Helper method for get_order_by() and get_distinct().
-
-        get_ordering() and get_distinct() must produce same target columns on
-        same input, as the prefixes of get_ordering() and get_distinct() must
-        match. Executing SQL where this is not true is an error.
-        """
         alias = alias or self.query.get_initial_alias()
         field, targets, opts, joins, path, transform_function = (
             self.query.setup_joins(pieces, opts, alias)
@@ -1253,16 +1176,6 @@ class SQLCompiler:
         return field, targets, alias, joins, path, opts, transform_function
 
     def get_from_clause(self):
-        """
-        Return a list of strings that are joined together to go after the
-        "FROM" part of the query, as well as a list any extra parameters that
-        need to be included. Subclasses, can override this to create a
-        from-clause via a "select".
-
-        This should only be called after any SQL construction methods that
-        might change the tables that are needed. This means the select columns,
-        ordering, and distinct must be done first.
-        """
         result = []
         params = []
         # Copy alias_map to a tuple in case Join.as_sql() subclasses (objects
@@ -1296,12 +1209,6 @@ class SQLCompiler:
         requested=None,
         restricted=None,
     ):
-        """
-        Fill in the information needed for a select_related query. The current
-        depth is measured as the number of connections away from the root model
-        (for example, cur_depth=1 means we are looking at models with direct
-        connections to the root model).
-        """
 
         def _get_field_choices():
             direct_choices = (f.name for f in opts.fields if f.is_relation)
@@ -1533,10 +1440,6 @@ class SQLCompiler:
         return related_klass_infos
 
     def get_select_for_update_of_arguments(self):
-        """
-        Return a quoted list of arguments for the SELECT FOR UPDATE OF part of
-        the query.
-        """
 
         def _get_parent_klass_info(klass_info):
             concrete_model = klass_info["model"]._meta.concrete_model
@@ -1563,20 +1466,12 @@ class SQLCompiler:
                 }
 
         def _get_first_selected_col_from_model(klass_info):
-            """
-            Find the first selected column from a model. If it doesn't exist,
-            don't lock a model.
-
-            select_fields is filled recursively, so it also contains fields
-            from the parent models.
-            """
             concrete_model = klass_info["model"]._meta.concrete_model
             for select_index in klass_info["select_fields"]:
                 if self.select[select_index][0].target.model == concrete_model:
                     return self.select[select_index][0]
 
         def _get_field_choices():
-            """Yield all allowed field paths in breadth-first search order."""
             queue = collections.deque([(None, self.klass_info)])
             while queue:
                 parent_path, klass_info = queue.popleft()
@@ -1710,7 +1605,6 @@ class SQLCompiler:
         chunked_fetch=False,
         chunk_size=GET_ITERATOR_CHUNK_SIZE,
     ):
-        """Return an iterator over the results from executing this query."""
         if results is None:
             results = await self.execute_sql(
                 MULTI, chunked_fetch=chunked_fetch, chunk_size=chunk_size
@@ -1727,10 +1621,6 @@ class SQLCompiler:
         return rows
 
     async def has_results(self):
-        """
-        Backends (e.g. NoSQL) can override this in order to use optimized
-        versions of "query has any results."
-        """
         return bool(await self.execute_sql(SINGLE))
 
     async def execute_sql(
@@ -1739,18 +1629,6 @@ class SQLCompiler:
         chunked_fetch=False,
         chunk_size=GET_ITERATOR_CHUNK_SIZE,
     ):
-        """
-        Run the query against the database and return the result(s). The
-        return value depends on the value of result_type.
-
-        When result_type is:
-        - MULTI: Retrieves all rows using fetchmany(). Wraps in an iterator for
-           chunked reads when supported.
-        - SINGLE: Retrieves a single row using fetchone().
-        - ROW_COUNT: Retrieves the number of rows in the result.
-        - CURSOR: Runs the query, and returns the cursor object. It is the
-           caller's responsibility to close the cursor.
-        """
         result_type = result_type or NO_RESULTS
         try:
             sql, params = self.as_sql()
@@ -1834,15 +1712,6 @@ class SQLInsertCompiler(SQLCompiler):
     returning_params = ()
 
     def field_as_sql(self, field, get_placeholder_sql, val):
-        """
-        Take a field and a value intended to be saved on that field, and
-        return placeholder SQL and accompanying params. Check for raw values,
-        fields with get_placeholder_sql(), and compilable defined in that
-        order.
-
-        When field is None, consider the value raw and use it as the
-        placeholder, with no corresponding parameters returned.
-        """
         if field is None:
             # A field value of None means the value is raw.
             sql, params = val, []
@@ -1867,10 +1736,6 @@ class SQLInsertCompiler(SQLCompiler):
         return sql, params
 
     def prepare_value(self, field, value):
-        """
-        Prepare a value to be used in a query by resolving it if it is an
-        expression and otherwise calling the field's get_db_prep_save().
-        """
         if hasattr(value, "resolve_expression"):
             value = value.resolve_expression(
                 self.query, allow_joins=False, for_save=True
@@ -1897,26 +1762,11 @@ class SQLInsertCompiler(SQLCompiler):
         return field.get_db_prep_save(value, connection=self.connection)
 
     def pre_save_val(self, field, obj):
-        """
-        Get the given field's value off the given obj. pre_save() is used for
-        things like auto_now on DateTimeField. Skip it if this is a raw query.
-        """
         if self.query.raw:
             return getattr(obj, field.attname)
         return field.pre_save(obj, add=True)
 
     def assemble_as_sql(self, fields, value_rows):
-        """
-        Take a sequence of N fields and a sequence of M rows of values, and
-        generate placeholder SQL and parameters for each field and value.
-        Return a pair containing:
-         * a sequence of M rows of N SQL placeholder strings, and
-         * a sequence of M rows of corresponding parameter values.
-
-        Each placeholder string may contain any number of '%s' interpolation
-        strings, and each parameter row will contain exactly as many params
-        as the total number of '%s's in the corresponding placeholder row.
-        """
         if not value_rows:
             return [], []
 
@@ -2170,10 +2020,6 @@ class SQLDeleteCompiler(SQLCompiler):
         return f"{delete} WHERE {where}", tuple(params)
 
     def as_sql(self):
-        """
-        Create the SQL for this query. Return the SQL string and list of
-        parameters.
-        """
         if self.single_alias and (
             self.connection.features.delete_can_self_reference_subquery
             or not self.contains_self_reference_subquery
@@ -2201,10 +2047,6 @@ class SQLUpdateCompiler(SQLCompiler):
     returning_params = ()
 
     def as_sql(self):
-        """
-        Create the SQL for this query. Return the SQL string and list of
-        parameters.
-        """
         self.pre_sql_setup()
         if not self.query.values:
             return "", ()
@@ -2280,12 +2122,6 @@ class SQLUpdateCompiler(SQLCompiler):
         return " ".join(result), tuple(update_params + params)
 
     async def execute_sql(self, result_type):
-        """
-        Execute the specified update. Return the number of rows affected by
-        the primary update query. The "primary update query" is the first
-        non-empty query that is executed. Row counts for any subsequent,
-        related queries are not available.
-        """
 
         if self.query.related_updates:
             raise NotImplementedError(
@@ -2311,11 +2147,6 @@ class SQLUpdateCompiler(SQLCompiler):
         return row_count
 
     async def execute_returning_sql(self, returning_fields):
-        """
-        Execute the specified update and return rows of the returned columns
-        associated with the specified returning_field if the backend supports
-        it.
-        """
         if self.query.get_related_updates():
             raise NotImplementedError(
                 "Update returning is not implemented for queries with related updates."
@@ -2343,14 +2174,6 @@ class SQLUpdateCompiler(SQLCompiler):
         return list(rows)
 
     def pre_sql_setup(self):
-        """
-        If the update depends on results from other tables, munge the "where"
-        conditions to match the format required for (portable) SQL updates.
-
-        If multiple updates are required, pull out the id values to update at
-        this point so that they don't change as a result of the progressive
-        updates.
-        """
         refcounts_before = self.query.alias_refcount.copy()
         # Ensure base table is in the query
         self.query.get_initial_alias()
@@ -2411,10 +2234,6 @@ class SQLUpdateCompiler(SQLCompiler):
 
 class SQLAggregateCompiler(SQLCompiler):
     def as_sql(self):
-        """
-        Create the SQL for this query. Return the SQL string and list of
-        parameters.
-        """
         sql, params = [], []
         for annotation in self.query.annotation_select.values():
             ann_sql, ann_params = self.compile(annotation)
@@ -2439,10 +2258,6 @@ class SQLAggregateCompiler(SQLCompiler):
 
 
 async def cursor_iter(cursor, sentinel, col_count, itersize):
-    """
-    Yield blocks of rows from a cursor and ensure the cursor is closed when
-    done.
-    """
 
     async def fetchmany_iter():
         while True:

--- a/django_async_backend/db/models/sql/query.py
+++ b/django_async_backend/db/models/sql/query.py
@@ -196,7 +196,6 @@ JoinInfo = namedtuple(
 
 
 class RawQuery:
-    """A single raw SQL query."""
 
     def __init__(self, sql, using, params=()):
         self.params = params
@@ -275,7 +274,6 @@ ExplainInfo = namedtuple("ExplainInfo", ("format", "options"))
 
 
 class Query(BaseExpression):
-    """A single SQL query."""
 
     alias_prefix = "T"
     empty_result_set_value = None
@@ -389,25 +387,13 @@ class Query(BaseExpression):
             return alias
 
     def __str__(self):
-        """
-        Return the query as a string of SQL with the parameter values
-        substituted in (use sql_with_params() to see the unsubstituted string).
-
-        Parameter values won't necessarily be quoted correctly, since that is
-        done by the database interface at execution time.
-        """
         sql, params = self.sql_with_params()
         return sql % params
 
     def sql_with_params(self):
-        """
-        Return the query as an SQL string and the parameters that will be
-        substituted into the query.
-        """
         return self.get_compiler(DEFAULT_DB_ALIAS).as_sql()
 
     def __deepcopy__(self, memo):
-        """Limit the amount of work when a Query is deepcopied."""
         result = self.clone()
         memo[id(self)] = result
         return result
@@ -422,19 +408,10 @@ class Query(BaseExpression):
         )
 
     def get_meta(self):
-        """
-        Return the Options instance (the model._meta) from which to start
-        processing. Normally, this is self.model._meta, but it can be changed
-        by subclasses.
-        """
         if self.model:
             return self.model._meta
 
     def clone(self):
-        """
-        Return a copy of the current Query. A lightweight alternative to
-        deepcopy().
-        """
         obj = Empty()
         obj.__class__ = self.__class__
         # Copy references to everything.
@@ -476,10 +453,6 @@ class Query(BaseExpression):
         return obj
 
     def chain(self, klass=None):
-        """
-        Return a copy of the current Query that's ready for another operation.
-        The klass argument changes the type of the Query, e.g. UpdateQuery.
-        """
         obj = self.clone()
         if klass and obj.__class__ != klass:
             obj.__class__ = klass
@@ -501,9 +474,6 @@ class Query(BaseExpression):
         return target.get_col(alias, field)
 
     async def get_aggregation(self, using, aggregate_exprs):
-        """
-        Return the dictionary with the values of the existing aggregations.
-        """
         if not aggregate_exprs:
             return {}
         # Store annotation mask prior to temporarily adding aggregations for
@@ -706,9 +676,6 @@ class Query(BaseExpression):
         return dict(zip(outer_query.annotation_select, result))
 
     async def get_count(self, using):
-        """
-        Perform a COUNT() query using the current filter constraints.
-        """
         obj = self.clone()
         return (await obj.get_aggregation(using, {"__count": Count("*")}))[
             "__count"
@@ -758,14 +725,6 @@ class Query(BaseExpression):
         return "\n".join([i async for i in compiler.explain_query()])
 
     def combine(self, rhs, connector):
-        """
-        Merge the 'rhs' query into the current one (with any 'rhs' effects
-        being applied *after* (that is, "to the right of") anything in the
-        current query. 'rhs' is not modified during a call to this function.
-
-        The 'connector' parameter describes how to connect filters from the
-        'rhs' query.
-        """
         if self.model != rhs.model:
             raise TypeError(
                 "Cannot combine queries on two different base models."
@@ -947,14 +906,6 @@ class Query(BaseExpression):
         return select_mask
 
     def get_select_mask(self):
-        """
-        Convert the self.deferred_loading data structure to an alternate data
-        structure, describing the field that *will* be loaded. This is used to
-        compute the columns to select from the database and also by the
-        QuerySet class to work out which fields are being initialized on each
-        model. Models that have all their fields included aren't mentioned in
-        the result, only those that have field restrictions in place.
-        """
         field_names, defer = self.deferred_loading
         if not field_names:
             return {}
@@ -969,13 +920,6 @@ class Query(BaseExpression):
         return self._get_only_select_mask(opts, mask)
 
     def table_alias(self, table_name, create=False, filtered_relation=None):
-        """
-        Return a table alias for the given table_name and whether this is a
-        new alias or not.
-
-        If 'create' is true, a new alias is always created. Otherwise, the
-        most recently created alias for the table (if one exists) is reused.
-        """
         alias_list = self.table_map.get(table_name)
         if not create and alias_list:
             alias = alias_list[0]
@@ -998,25 +942,12 @@ class Query(BaseExpression):
         return alias, True
 
     def ref_alias(self, alias):
-        """Increases the reference count for this alias."""
         self.alias_refcount[alias] += 1
 
     def unref_alias(self, alias, amount=1):
-        """Decreases the reference count for this alias."""
         self.alias_refcount[alias] -= amount
 
     def promote_joins(self, aliases):
-        """
-        Promote recursively the join type of given aliases and its children to
-        an outer join. If 'unconditional' is False, only promote the join if
-        it is nullable or the parent join is an outer join.
-
-        The children promotion is done to avoid join chains that contain a
-        LOUTER b INNER c. So, if we have currently a INNER b INNER c and a->b
-        is promoted, then we must also promote b->c automatically, or otherwise
-        the promotion of a->b doesn't actually change anything in the query
-        results.
-        """
         aliases = list(aliases)
         while aliases:
             alias = aliases.pop(0)
@@ -1047,15 +978,6 @@ class Query(BaseExpression):
                 )
 
     def demote_joins(self, aliases):
-        """
-        Change join type from LOUTER to INNER for all joins in aliases.
-
-        Similarly to promote_joins(), this method must ensure no join chains
-        containing first an outer, then an inner join are generated. If we
-        are demoting b->c join in chain a LOUTER b LOUTER c then we must
-        demote a->b automatically, or otherwise the demotion of b->c doesn't
-        actually change anything in the query results. .
-        """
         aliases = list(aliases)
         while aliases:
             alias = aliases.pop(0)
@@ -1066,20 +988,11 @@ class Query(BaseExpression):
                     aliases.append(parent_alias)
 
     def reset_refcounts(self, to_counts):
-        """
-        Reset reference counts for aliases so that they match the value passed
-        in `to_counts`.
-        """
         for alias, cur_refcount in self.alias_refcount.copy().items():
             unref_amount = cur_refcount - to_counts.get(alias, 0)
             self.unref_alias(alias, unref_amount)
 
     def change_aliases(self, change_map):
-        """
-        Change the aliases in change_map (which maps old-alias -> new-alias),
-        relabelling any references to them in select columns and the where
-        clause.
-        """
         if not change_map:
             return self
         # If keys and values of change_map were to intersect, an alias might be
@@ -1134,22 +1047,8 @@ class Query(BaseExpression):
             combined_query.change_aliases(external_change_map)
 
     def bump_prefix(self, other_query, exclude=None):
-        """
-        Change the alias prefix to the next letter in the alphabet in a way
-        that the other query's aliases and this query's aliases will not
-        conflict. Even tables that previously had no alias will get an alias
-        after this call. To prevent changing aliases use the exclude parameter.
-        """
 
         def prefix_gen():
-            """
-            Generate a sequence of characters in alphabetical order:
-                -> 'A', 'B', 'C', ...
-
-            When the alphabet is finished, the sequence will continue with the
-            Cartesian product:
-                -> 'AA', 'AB', 'AC', ...
-            """
             alphabet = ascii_uppercase
             prefix = chr(ord(self.alias_prefix) + 1)
             yield prefix
@@ -1193,10 +1092,6 @@ class Query(BaseExpression):
         )
 
     def get_initial_alias(self):
-        """
-        Return the first alias for this query, after increasing its reference
-        count.
-        """
         if self.alias_map:
             alias = self.base_table
             self.ref_alias(alias)
@@ -1209,26 +1104,9 @@ class Query(BaseExpression):
         return alias
 
     def count_active_tables(self):
-        """
-        Return the number of tables in this query with a non-zero reference
-        count. After execution, the reference counts are zeroed, so tables
-        added in compiler will not be seen by this method.
-        """
         return len([1 for count in self.alias_refcount.values() if count])
 
     def join(self, join, reuse=None):
-        """
-        Return an alias for the 'join', either reusing an existing alias for
-        that join or creating a new one. 'join' is either a base_table_class or
-        join_class.
-
-        The 'reuse' parameter can be either None which means all joins are
-        reusable, or it can be a set containing the aliases that can be reused.
-
-        A join is always created as LOUTER if the lhs alias is LOUTER to make
-        sure chains like t1 LOUTER t2 INNER t3 aren't generated. All new
-        joins are created as LOUTER if the join is nullable.
-        """
         reuse_aliases = [
             a
             for a, j in self.alias_map.items()
@@ -1276,14 +1154,6 @@ class Query(BaseExpression):
         return alias
 
     def join_parent_model(self, opts, model, alias, seen):
-        """
-        Make sure the given 'model' is joined in the query. If 'model' isn't
-        a parent of 'opts' or if it is None this method is a no-op.
-
-        The 'alias' is the root alias for starting the join, 'seen' is a dict
-        of model -> alias of existing joins. It must also contain a mapping
-        of None -> some alias. This will be returned in the no-op case.
-        """
         if model in seen:
             return seen[model]
         chain = opts.get_base_chain(model)
@@ -1327,7 +1197,6 @@ class Query(BaseExpression):
             )
 
     def add_annotation(self, annotation, alias, select=True):
-        """Add a single annotation expression to the Query."""
         self.check_alias(alias)
         annotation = annotation.resolve_expression(
             self, allow_joins=True, reuse=None
@@ -1442,9 +1311,6 @@ class Query(BaseExpression):
         return value
 
     def solve_lookup_type(self, lookup, summarize=False):
-        """
-        Solve the lookup type from the lookup (e.g.: 'foobar__id__icontains').
-        """
         lookup_splitted = lookup.split(LOOKUP_SEP)
         if self.annotations:
             annotation, expression_lookups = refs_expression(
@@ -1469,10 +1335,6 @@ class Query(BaseExpression):
         return lookup_parts, field_parts, False
 
     def check_query_object_type(self, value, opts, field):
-        """
-        Check whether the object passed while querying is of the correct type.
-        If not, raise a ValueError specifying the wrong object.
-        """
         if hasattr(value, "_meta"):
             if not check_rel_lookup_compatibility(
                 value._meta.model, opts, field
@@ -1483,7 +1345,6 @@ class Query(BaseExpression):
                 )
 
     def check_related_objects(self, field, value, opts):
-        """Check the type of object passed to query relations."""
         if field.is_relation:
             # Check that the field and the queryset use the same model in a
             # query like .filter(author=Author.objects.all()). For example, the
@@ -1508,7 +1369,6 @@ class Query(BaseExpression):
                     self.check_query_object_type(v, opts, field)
 
     def check_filterable(self, expression):
-        """Raise an error if expression cannot be used in a WHERE clause."""
         if hasattr(expression, "resolve_expression") and not getattr(
             expression, "filterable", True
         ):
@@ -1521,14 +1381,6 @@ class Query(BaseExpression):
                 self.check_filterable(expr)
 
     def build_lookup(self, lookups, lhs, rhs):
-        """
-        Try to extract transforms and lookup from given lhs.
-
-        The lhs value is something that works like SQLExpression.
-        The rhs value is what the lookup is going to compare against.
-        The lookups is a list of names to extract using get_lookup()
-        and get_transform().
-        """
         # __exact is the default lookup if one isn't given.
         *transforms, lookup_name = lookups or ["exact"]
         for name in transforms:
@@ -1569,10 +1421,6 @@ class Query(BaseExpression):
         return lookup
 
     def try_transform(self, lhs, name, lookups=None):
-        """
-        Helper method for build_lookup(). Try to fetch and initialize
-        a transform for name parameter from lhs.
-        """
         transform_class = lhs.get_transform(name)
         if transform_class:
             return transform_class(lhs)
@@ -1610,31 +1458,6 @@ class Query(BaseExpression):
         summarize=False,
         update_join_types=True,
     ):
-        """
-        Build a WhereNode for a single filter clause but don't add it
-        to this Query. Query.add_q() will then add this filter to the where
-        Node.
-
-        The 'branch_negated' tells us if the current branch contains any
-        negations. This will be used to determine if subqueries are needed.
-
-        The 'current_negated' is used to determine if the current filter is
-        negated or not and this will be used to determine if IS NULL filtering
-        is needed.
-
-        The difference between current_negated and branch_negated is that
-        branch_negated is set on first negation, but current_negated is
-        flipped for each negation.
-
-        Note that add_filter will not do any negating itself, that is done
-        upper in the code by add_q().
-
-        The 'can_reuse' is a set of reusable joins for multijoins.
-
-        The method will create a filter clause that can be added to the current
-        query. However, if the filter isn't added to the query then the caller
-        is responsible for unreffing the joins used.
-        """
         if isinstance(filter_expr, dict):
             raise FieldError("Cannot parse keyword query as dict")
         if isinstance(filter_expr, Q):
@@ -1797,10 +1620,6 @@ class Query(BaseExpression):
         self.add_q(Q((filter_lhs, filter_rhs)))
 
     def add_q(self, q_object, reuse_all=False):
-        """
-        A preprocessor for the internal _add_q(). Responsible for doing final
-        join promotion.
-        """
         # For join promotion this case is doing an AND for the added q_object
         # and existing conditions. So, any existing inner join forces the join
         # type to remain inner. Existing outer joins can however be demoted.
@@ -1837,7 +1656,6 @@ class Query(BaseExpression):
         summarize=False,
         update_join_types=True,
     ):
-        """Add a Q-object to the current filter."""
         connector = q_object.connector
         current_negated ^= q_object.negated
         branch_negated = branch_negated or q_object.negated
@@ -1915,20 +1733,6 @@ class Query(BaseExpression):
     def names_to_path(
         self, names, opts, allow_many=True, fail_on_missing=False
     ):
-        """
-        Walk the list of names and turns them into PathInfo tuples. A single
-        name in 'names' can generate multiple PathInfos (m2m, for example).
-
-        'names' is the path of names to travel, 'opts' is the model Options we
-        start the name resolving from, 'allow_many' is as for setup_joins().
-        If fail_on_missing is set to True, then a name that can't be resolved
-        will generate a FieldError.
-
-        Return a list of PathInfo tuples. In addition return the final field
-        (the last used join field) and target (which is a field guaranteed to
-        contain the same value as the final field). Finally, return those names
-        that weren't found (which are likely transforms and the final lookup).
-        """
         path, names_with_path = [], []
         for pos, name in enumerate(names):
             cur_names_with_path = (name, [])
@@ -2044,33 +1848,6 @@ class Query(BaseExpression):
         can_reuse=None,
         allow_many=True,
     ):
-        """
-        Compute the necessary table joins for the passage through the fields
-        given in 'names'. 'opts' is the Options class for the current model
-        (which gives the table we are starting from), 'alias' is the alias for
-        the table to start the joining from.
-
-        The 'can_reuse' defines the reverse foreign key joins we can reuse. It
-        can be None in which case all joins are reusable or a set of aliases
-        that can be reused. Note that non-reverse foreign keys are always
-        reusable when using setup_joins().
-
-        If 'allow_many' is False, then any reverse foreign key seen will
-        generate a MultiJoin exception.
-
-        Return the final field involved in the joins, the target field (used
-        for any 'where' constraint), the final 'opts' value, the joins, the
-        field path traveled to generate the joins, and a transform function
-        that takes a field and alias and is equivalent to
-        `field.get_col(alias)` in the simple case but wraps field transforms if
-        they were included in names.
-
-        The target field is the field containing the concrete value. Final
-        field can be something different, for example foreign key pointing to
-        that value. Final field is needed for example in some value
-        conversions (convert 'obj' in fk__id=obj to pk val using the foreign
-        key field for example).
-        """
         joins = [alias]
         # The transform can't be applied yet, as joins must be trimmed later.
         # To avoid making every caller of this method look up transforms
@@ -2156,18 +1933,6 @@ class Query(BaseExpression):
         )
 
     def trim_joins(self, targets, joins, path):
-        """
-        The 'target' parameter is the final field being joined to, 'joins'
-        is the full list of join aliases. The 'path' contain the PathInfos
-        used to create the joins.
-
-        Return the final target field and table alias and the new active
-        joins.
-
-        Always trim any direct join if the target column is already in the
-        previous table. Can't trim reverse joins as it's unknown if there's
-        anything on the other side of the join.
-        """
         joins = joins[:]
         for pos, info in enumerate(reversed(path)):
             if len(joins) == 1 or not info.direct:
@@ -2266,24 +2031,6 @@ class Query(BaseExpression):
             return transform
 
     def split_exclude(self, filter_expr, can_reuse, names_with_path):
-        """
-        When doing an exclude against any kind of N-to-many relation, we need
-        to use a subquery. This method constructs the nested query, given the
-        original exclude filter (filter_expr) and the portion up to the first
-        N-to-many relation field.
-
-        For example, if the origin filter is ~Q(child__name='foo'), filter_expr
-        is ('child__name', 'foo') and can_reuse is a set of joins usable for
-        filters in the original query.
-
-        We will turn this into equivalent of:
-            WHERE NOT EXISTS(
-                SELECT 1
-                FROM child
-                WHERE name = 'foo' AND child.parent_id = parent.id
-                LIMIT 1
-            )
-        """
         # Generate the inner query.
         query = self.__class__(self.model)
         query._filtered_relations = self._filtered_relations
@@ -2345,14 +2092,6 @@ class Query(BaseExpression):
         return any(isinstance(c, NothingNode) for c in self.where.children)
 
     def set_limits(self, low=None, high=None):
-        """
-        Adjust the limits on the rows retrieved. Use low/high to set these,
-        as it makes it more Pythonic to read and write. When the SQL query is
-        created, convert them to the appropriate offset and limit values.
-
-        Apply any limits passed in here to the existing constraints. Add low
-        to the current low value and clamp both to any existing high value.
-        """
         if high is not None:
             if self.high_mark is not None:
                 self.high_mark = min(self.high_mark, self.low_mark + high)
@@ -2368,7 +2107,6 @@ class Query(BaseExpression):
             self.set_empty()
 
     def clear_limits(self):
-        """Clear any existing limits."""
         self.low_mark, self.high_mark = 0, None
 
     @property
@@ -2382,16 +2120,9 @@ class Query(BaseExpression):
         )
 
     def can_filter(self):
-        """
-        Return True if adding filters to this instance is still possible.
-
-        Typically, this means no limits or offsets have been put on the
-        results.
-        """
         return not self.is_sliced
 
     def clear_select_clause(self):
-        """Remove all fields from SELECT clause."""
         self.select = ()
         self.default_cols = False
         self.select_related = False
@@ -2400,11 +2131,6 @@ class Query(BaseExpression):
         self.selected = None
 
     def clear_select_fields(self):
-        """
-        Clear the list of fields to select (but not extra_select columns).
-        Some queryset types completely replace any existing list of select
-        columns.
-        """
         self.select = ()
         self.values_select = ()
         self.selected = None
@@ -2419,17 +2145,10 @@ class Query(BaseExpression):
         self.select = tuple(cols)
 
     def add_distinct_fields(self, *field_names):
-        """
-        Add and resolve the given fields to the query's "distinct on" clause.
-        """
         self.distinct_fields = field_names
         self.distinct = True
 
     def add_fields(self, field_names, allow_m2m=True):
-        """
-        Add the given (model) fields to the select set. Add the field names in
-        the order specified.
-        """
         alias = self.get_initial_alias()
         opts = self.get_meta()
 
@@ -2487,14 +2206,6 @@ class Query(BaseExpression):
                 )
 
     def add_ordering(self, *ordering):
-        """
-        Add items from the 'ordering' sequence to the query's "order by"
-        clause. These items are either field names (not column names) --
-        possibly with a direction prefix ('-' or '?') -- or OrderBy
-        expressions.
-
-        If 'ordering' is empty, clear all ordering from the query.
-        """
         errors = []
         for item in ordering:
             if isinstance(item, str):
@@ -2553,12 +2264,6 @@ class Query(BaseExpression):
         return order_by_set.issubset(self.group_by)
 
     def clear_ordering(self, force=False, clear_default=True):
-        """
-        Remove any ordering settings if the current query allows it without
-        side effects, set 'force' to True to clear the ordering regardless.
-        If 'clear_default' is True, there will be no ordering in the resulting
-        query (not even the model's default).
-        """
         if not force and (
             self.is_sliced or self.distinct_fields or self.select_for_update
         ):
@@ -2574,14 +2279,6 @@ class Query(BaseExpression):
             query.clear_ordering(force=False, clear_default=clear_default)
 
     def set_group_by(self, allow_aliases=True):
-        """
-        Expand the GROUP BY clause required by the query.
-
-        This will usually be the set of all non-aggregate fields in the
-        return data. If the database backend supports grouping by the
-        primary key, and the query would be equivalent, the optimization
-        will be made automatically.
-        """
         if allow_aliases and self.values_select:
             # If grouping by aliases is allowed assign selected value aliases
             # by moving them to annotations.
@@ -2610,11 +2307,6 @@ class Query(BaseExpression):
         self.group_by = tuple(group_by)
 
     def add_select_related(self, fields):
-        """
-        Set up the select_related data structure so that we only select
-        certain related models (as opposed to all models, when
-        self.select_related=True).
-        """
         if isinstance(self.select_related, bool):
             field_dict = {}
         else:
@@ -2628,10 +2320,6 @@ class Query(BaseExpression):
     def add_extra(
         self, select, select_params, where, params, tables, order_by
     ):
-        """
-        Add data to the various extra_* attributes for user-created additions
-        to the query.
-        """
         if select:
             # We need to pair any placeholder markers in the 'select'
             # dictionary with their parameters in 'select_params' so that
@@ -2661,17 +2349,9 @@ class Query(BaseExpression):
             self.extra_order_by = order_by
 
     def clear_deferred_loading(self):
-        """Remove any fields from the deferred loading set."""
         self.deferred_loading = (frozenset(), True)
 
     def add_deferred_loading(self, field_names):
-        """
-        Add the given list of model field names to the set of fields to
-        exclude from loading from the database when automatic column selection
-        is done. Add the new field names to any existing field names that
-        are deferred (or removed from any existing field names that are marked
-        as the only ones for immediate loading).
-        """
         # Fields on related models are stored in the literal double-underscore
         # format, so that we can use a set datastructure. We do the foo__bar
         # splitting and handling when computing the SQL column names (as part
@@ -2690,15 +2370,6 @@ class Query(BaseExpression):
                     self.deferred_loading = new_only, True
 
     def add_immediate_loading(self, field_names):
-        """
-        Add the given list of model field names to the set of fields to
-        retrieve when the SQL is executed ("immediate loading" fields). The
-        field names replace any existing immediate loading field names. If
-        there are field names already specified for deferred loading, remove
-        those names from the new field_names before storing the new names
-        for immediate loading. (That is, immediate loading overrides any
-        existing immediate values, but respects existing deferrals.)
-        """
         existing, defer = self.deferred_loading
         field_names = set(field_names)
         if "pk" in field_names:
@@ -2714,7 +2385,6 @@ class Query(BaseExpression):
             self.deferred_loading = frozenset(field_names), False
 
     def set_annotation_mask(self, names):
-        """Set the mask of annotations that will be returned by the SELECT."""
         if names is None:
             self.annotation_select_mask = None
         else:
@@ -2737,10 +2407,6 @@ class Query(BaseExpression):
             self.set_annotation_mask(self.annotation_select_mask.union(names))
 
     def set_extra_mask(self, names):
-        """
-        Set the mask of extra select items that will be returned by SELECT.
-        Don't remove them from the Query since they might be used later.
-        """
         if names is None:
             self.extra_select_mask = None
         else:
@@ -2830,10 +2496,6 @@ class Query(BaseExpression):
 
     @property
     def annotation_select(self):
-        """
-        Return the dictionary of aggregate columns that are not masked and
-        should be used in the SELECT clause. Cache this result for performance.
-        """
         if self._annotation_select_cache is not None:
             return self._annotation_select_cache
         elif not self.annotations:
@@ -2865,19 +2527,6 @@ class Query(BaseExpression):
             return self.extra
 
     def trim_start(self, names_with_path):
-        """
-        Trim joins from the start of the join path. The candidates for trim
-        are the PathInfos in names_with_path structure that are m2m joins.
-
-        Also set the select column so the start matches the join.
-
-        This method is meant to be used for generating the subquery joins &
-        cols in split_exclude().
-
-        Return a lookup usable for doing outerq.filter(lookup=self) and a
-        boolean indicating if the joins in the prefix contain a LEFT OUTER
-        join.
-        """
         all_paths = []
         for _, paths in names_with_path:
             all_paths.extend(paths)
@@ -2949,13 +2598,6 @@ class Query(BaseExpression):
         return trimmed_prefix, contains_louter
 
     def is_nullable(self, field):
-        """
-        Check if the given field should be treated as nullable.
-
-        Some backends treat '' as null and Django treats such fields as
-        nullable for those backends. In such situations field.null can be
-        False even if we should treat the field as nullable.
-        """
         # We need to use DEFAULT_DB_ALIAS here, as QuerySet does not have
         # (nor should it have) knowledge of which connection is going to be
         # used. The proper fix would be to defer all decisions where
@@ -2970,13 +2612,6 @@ class Query(BaseExpression):
 
 
 def get_order_dir(field, default="ASC"):
-    """
-    Return the field name and direction for an order specification. For
-    example, '-foo' is returned as ('foo', 'DESC').
-
-    The 'default' param is used to indicate which way no prefix (or a '+'
-    prefix) should sort. The '-' prefix always sorts the opposite way.
-    """
     dirn = ORDER_DIR[default]
     if field[0] == "-":
         return field[1:], dirn[1]
@@ -2984,10 +2619,6 @@ def get_order_dir(field, default="ASC"):
 
 
 class JoinPromoter:
-    """
-    A class to abstract away join promotion problems for complex filter
-    conditions.
-    """
 
     def __init__(self, connector, num_children, negated):
         self.connector = connector
@@ -3011,19 +2642,9 @@ class JoinPromoter:
         )
 
     def add_votes(self, votes):
-        """
-        Add single vote per item to self.votes. Parameter can be any
-        iterable.
-        """
         self.votes.update(votes)
 
     def update_join_types(self, query):
-        """
-        Change join types so that the generated query is as efficient as
-        possible, but still correct. So, change as many joins as possible
-        to INNER, but don't make OUTER joins INNER if that could remove
-        results from the query.
-        """
         to_promote = set()
         to_demote = set()
         # The effective_connector is used so that NOT (a AND b) is treated

--- a/django_async_backend/db/models/sql/subqueries.py
+++ b/django_async_backend/db/models/sql/subqueries.py
@@ -16,7 +16,6 @@ __all__ = ["DeleteQuery", "UpdateQuery", "InsertQuery", "AggregateQuery"]
 
 
 class DeleteQuery(Query):
-    """A DELETE SQL query."""
 
     compiler = "SQLDeleteCompiler"
 
@@ -26,12 +25,6 @@ class DeleteQuery(Query):
         return await self.get_compiler(using).execute_sql(ROW_COUNT)
 
     async def delete_batch(self, pk_list, using):
-        """
-        Set up and execute delete queries for all the objects in pk_list.
-
-        More than one physical query may be executed if there are a
-        lot of values in pk_list.
-        """
         # number of objects deleted
         num_deleted = 0
         field = self.get_meta().pk
@@ -48,7 +41,6 @@ class DeleteQuery(Query):
 
 
 class UpdateQuery(Query):
-    """An UPDATE SQL query."""
 
     compiler = "SQLUpdateCompiler"
 
@@ -57,10 +49,6 @@ class UpdateQuery(Query):
         self._setup_query()
 
     def _setup_query(self):
-        """
-        Run on initialization and at the end of chaining. Any attributes that
-        would normally be set in __init__() should go here instead.
-        """
         self.values = []
         self.related_ids = None
         self.related_updates = {}
@@ -80,11 +68,6 @@ class UpdateQuery(Query):
             await self.get_compiler(using).execute_sql(NO_RESULTS)
 
     def add_update_values(self, values):
-        """
-        Convert a dictionary of field name to value mappings into an update
-        query. This is the entry point for the public update() method on
-        querysets.
-        """
         values_seq = []
         for name, val in values.items():
             field = self.get_meta().get_field(name)
@@ -105,11 +88,6 @@ class UpdateQuery(Query):
         return self.add_update_fields(values_seq)
 
     def add_update_fields(self, values_seq):
-        """
-        Append a sequence of (field, model, value) triples to the internal list
-        that will be used to generate the UPDATE query. Might be more usefully
-        called add_update_targets() to hint at the extra information here.
-        """
         for field, model, val in values_seq:
             # Omit generated fields.
             if field.generated:
@@ -123,19 +101,9 @@ class UpdateQuery(Query):
             self.values.append((field, model, val))
 
     def add_related_update(self, model, field, value):
-        """
-        Add (name, value) to an update query for an ancestor model.
-
-        Update are coalesced so that only one update query per ancestor is run.
-        """
         self.related_updates.setdefault(model, []).append((field, None, value))
 
     def get_related_updates(self):
-        """
-        Return a list of query objects: one for each update required to an
-        ancestor model. Each query will have the same filtering conditions as
-        the current query but will only update a single table.
-        """
         if not self.related_updates:
             return []
         result = []


### PR DESCRIPTION
## Summary by Sourcery

Strip docstrings from generated and asynchronous Django source while preserving code structure and comments.

New Features:
- Add a CST transformer that removes module, class, and function docstrings while preserving leading comments and maintaining valid empty bodies.

Enhancements:
- Remove existing docstrings throughout the asynchronous Django model and SQL implementation to reduce embedded documentation and generated source size.