### PR TITLE
fix: release only the connections a context opened

### DIFF
--- a/django_async_backend/db/__init__.py
+++ b/django_async_backend/db/__init__.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from django_async_backend.db.new_connection import async_new_connection
 from django_async_backend.db.utils import async_connections
 
@@ -9,9 +11,31 @@ __all__ = [
 
 
 async def close_old_async_connections(**kwargs):
-    # Close every configured connection alias. close() is a no-op on a
-    # wrapper with no underlying connection, so walking aliases this
-    # task hasn't touched is free. **kwargs lets the same function be
-    # connected as a request_started / request_finished signal handler.
-    for conn in async_connections.all():
-        await conn.close()
+    """Release the connections this context opened.
+
+    Connected to request_started and request_finished. Django runs an
+    async receiver in a task of its own and copies its context changes
+    back out, so what this leaves in the store is what the request
+    inherits, owning task included.
+    """
+    # all() would build a wrapper per unopened alias: owned by this task,
+    # and impossible to build at all for a non-async alias.
+    conns = async_connections.all(initialized_only=True)
+
+    # Dropped, not just closed: close() keeps the wrapper and its owner.
+    # One in an atomic block stays, as the tombstone close() makes of it;
+    # replacing it would put the rest of the block outside its
+    # transaction.
+    for conn in conns:
+        if not conn.in_atomic_block:
+            del async_connections[conn.alias]
+
+    # The store is already clear, so a close that fails can neither
+    # strand nor leak the others.
+    results = await asyncio.gather(
+        *(conn.close() for conn in conns), return_exceptions=True
+    )
+
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result

--- a/django_async_backend/db/new_connection.py
+++ b/django_async_backend/db/new_connection.py
@@ -15,8 +15,16 @@ async def _new_connection_scope():
     The previous connections are restored rather than dropped: the caller
     may already be using one, and orphaning it would silently open a
     second connection on its next query.
+
+    Only the aliases the caller actually opened are swapped.
+    ``all()`` without ``initialized_only`` would build a wrapper for every
+    configured alias -- and raise outright for one whose backend has no
+    async wrapper, which is any ordinary Django alias -- to swap
+    connections nothing in the block is going to use. An alias the block
+    opens for the first time gets its own connection anyway, because
+    there is nothing in the store for it to inherit.
     """
-    previous = async_connections.all()
+    previous = async_connections.all(initialized_only=True)
 
     for conn in previous:
         async_connections[conn.alias] = async_connections.create_connection(
@@ -26,7 +34,7 @@ async def _new_connection_scope():
     try:
         yield
     finally:
-        opened = async_connections.all()
+        opened = async_connections.all(initialized_only=True)
 
         close_task = asyncio.gather(*[conn.close() for conn in opened])
 

--- a/tests/db/test_close_old_async_connections.py
+++ b/tests/db/test_close_old_async_connections.py
@@ -1,33 +1,210 @@
-from unittest.mock import AsyncMock, patch
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
 
-from django.test import SimpleTestCase
+from asgiref.sync import sync_to_async
+from django.core import signals
+from django.db import (
+    DEFAULT_DB_ALIAS,
+    DatabaseError,
+)
 
 from django_async_backend.db import (
     async_connections,
     close_old_async_connections,
 )
+from django_async_backend.db.transaction import async_atomic
 
 
-class CloseOldAsyncConnectionsTest(SimpleTestCase):
-    async def test_closes_every_configured_alias(self):
-        first = AsyncMock()
-        first.alias = "first"
-        second = AsyncMock()
-        second.alias = "second"
+def stored_aliases():
+    """Aliases the current context actually holds a wrapper for."""
+    return sorted(
+        conn.alias for conn in async_connections.all(initialized_only=True)
+    )
 
-        with patch.object(
-            async_connections, "all", return_value=[first, second]
-        ) as mocked_all:
+
+class ReleaseTestCase(IsolatedAsyncioTestCase):
+    databases = "__all__"
+
+    async def asyncSetUp(self):
+        await self.drain()
+
+    async def asyncTearDown(self):
+        await self.drain()
+
+    async def drain(self):
+        """Empty the store without going through the code under test."""
+        for conn in async_connections.all(initialized_only=True):
+            del async_connections[conn.alias]
+            try:
+                await conn.close()
+            except Exception:
+                # A test may have deliberately broken this connection.
+                pass
+
+
+class CloseOldAsyncConnectionsTest(ReleaseTestCase):
+    async def test_releases_the_aliases_this_context_opened(self):
+        first = async_connections[DEFAULT_DB_ALIAS]
+        second = async_connections["other"]
+        self.assertEqual(stored_aliases(), ["default", "other"])
+
+        await close_old_async_connections()
+
+        self.assertEqual(stored_aliases(), [])
+        # Dropped, not merely closed: the next access builds a new wrapper
+        # owned by whichever task asks for it, rather than handing back one
+        # owned by a task that has moved on.
+        self.assertIsNot(async_connections[DEFAULT_DB_ALIAS], first)
+        self.assertIsNot(async_connections["other"], second)
+
+    async def test_does_not_open_aliases_this_context_never_used(self):
+        create_connection = async_connections.create_connection
+        opened = []
+
+        def spy(alias):
+            opened.append(alias)
+            return create_connection(alias)
+
+        with patch.object(async_connections, "create_connection", spy):
             await close_old_async_connections()
 
-        mocked_all.assert_called_once_with()
-        first.close.assert_awaited_once_with()
-        second.close.assert_awaited_once_with()
+        self.assertEqual(opened, [])
+
+    async def test_ignores_an_alias_that_is_not_an_async_backend(self):
+        # A project adopting this library can have an ordinary Django
+        # alias alongside an async one. Building a wrapper for it raises,
+        # so an untouched alias must not be built.
+        async_connections.settings["legacy"] = dict(
+            async_connections.settings[DEFAULT_DB_ALIAS],
+            ENGINE="django.db.backends.postgresql",
+        )
+        self.addCleanup(async_connections.settings.pop, "legacy")
+        async_connections[DEFAULT_DB_ALIAS]
+
+        await close_old_async_connections()
+
+        self.assertEqual(stored_aliases(), [])
+
+    async def test_closes_the_underlying_connection(self):
+        connection = async_connections[DEFAULT_DB_ALIAS]
+        async with await connection.cursor() as cursor:
+            await cursor.execute("SELECT 1")
+        self.assertIsNotNone(connection.connection)
+
+        await close_old_async_connections()
+
+        self.assertIsNone(connection.connection)
+
+    async def test_closes_every_alias_even_when_one_fails(self):
+        failing = async_connections[DEFAULT_DB_ALIAS]
+        healthy = async_connections["other"]
+        await healthy.ensure_connection()
+
+        async def close():
+            raise DatabaseError("cannot hand this one back")
+
+        failing.close = close
+
+        with self.assertRaises(DatabaseError):
+            await close_old_async_connections()
+
+        # The healthy alias is released rather than left open and
+        # unreachable, and no wrapper is left for the next task.
+        self.assertIsNone(healthy.connection)
+        self.assertEqual(stored_aliases(), [])
+
+    async def test_keeps_a_wrapper_that_is_inside_a_transaction(self):
+        connection = async_connections[DEFAULT_DB_ALIAS]
+        reached_the_assertions = False
+
+        try:
+            async with async_atomic():
+                await close_old_async_connections()
+
+                # The tombstone stays, so the rest of the block cannot
+                # silently carry on against a fresh connection outside
+                # its transaction.
+                self.assertIs(async_connections[DEFAULT_DB_ALIAS], connection)
+                self.assertTrue(connection.closed_in_transaction)
+                reached_the_assertions = True
+        except DatabaseError:
+            # Leaving the block reports the broken transaction. That is
+            # the point: the failure is loud.
+            pass
+
+        self.assertTrue(reached_the_assertions)
 
     async def test_accepts_signal_kwargs(self):
-        """Connected as a request_started/request_finished signal handler
-        in some deployments — must accept arbitrary kwargs."""
-        with patch.object(async_connections, "all", return_value=[]):
-            await close_old_async_connections(
-                sender=object(), signal=object(), environ={}
-            )
+        """Connected as a request_started / request_finished receiver, so
+        it has to tolerate whatever the sender passes."""
+        await async_connections[DEFAULT_DB_ALIAS].ensure_connection()
+
+        await close_old_async_connections(
+            sender=object(), signal=object(), scope={}
+        )
+
+        self.assertEqual(stored_aliases(), [])
+
+
+class RequestSignalsTest(ReleaseTestCase):
+    """Release through the signals the app connects on startup.
+
+    These deliberately avoid AsyncioTransactionTestCase, which re-stamps
+    ownership of every alias before each test method -- the very state
+    under test here.
+    """
+
+    def test_the_app_connects_the_receiver(self):
+        for signal in (signals.request_started, signals.request_finished):
+            with self.subTest(signal=signal):
+                _, async_receivers = signal._live_receivers(None)
+                self.assertIn(close_old_async_connections, async_receivers)
+
+    async def test_request_started_releases_a_stale_connection(self):
+        stale = async_connections[DEFAULT_DB_ALIAS]
+        await stale.ensure_connection()
+
+        await signals.request_started.asend(sender=None, scope={})
+
+        self.assertEqual(stored_aliases(), [])
+        self.assertIsNone(stale.connection)
+
+    async def test_request_started_opens_nothing_on_an_empty_store(self):
+        await signals.request_started.asend(sender=None, scope={})
+
+        self.assertEqual(stored_aliases(), [])
+
+    async def test_request_started_leaves_no_foreign_connection(self):
+        await signals.request_started.asend(sender=None, scope={})
+
+        async_connections[DEFAULT_DB_ALIAS].validate_task_sharing()
+
+    async def test_a_request_can_query_after_request_started(self):
+        await signals.request_started.asend(sender=None, scope={})
+
+        connection = async_connections[DEFAULT_DB_ALIAS]
+        async with await connection.cursor() as cursor:
+            await cursor.execute("SELECT 1")
+            self.assertEqual(await cursor.fetchone(), (1,))
+
+    async def test_request_finished_releases_what_the_request_opened(self):
+        connection = async_connections[DEFAULT_DB_ALIAS]
+        await connection.ensure_connection()
+        self.assertEqual(stored_aliases(), [DEFAULT_DB_ALIAS])
+
+        await signals.request_finished.asend(sender=None)
+
+        self.assertEqual(stored_aliases(), [])
+        self.assertIsNone(connection.connection)
+
+    async def test_request_finished_releases_from_a_sync_send(self):
+        # ASGIHandler does not asend() request_finished for a normal
+        # response: it awaits sync_to_async(response.close), and
+        # HttpResponse.close() sends the signal synchronously.
+        connection = async_connections[DEFAULT_DB_ALIAS]
+        await connection.ensure_connection()
+
+        await sync_to_async(signals.request_finished.send)(sender=None)
+
+        self.assertEqual(stored_aliases(), [])
+        self.assertIsNone(connection.connection)

--- a/tests/db/test_new_connection.py
+++ b/tests/db/test_new_connection.py
@@ -145,3 +145,24 @@ class AsyncNewConnectionTests(AsyncioTransactionTestCase):
         self.assertIs(after, before)
         self.assertIsNotNone(after.connection)
         self.assertEqual(await names(), ["inner"])
+
+    async def test_ignores_an_alias_that_is_not_an_async_backend(self):
+        """A project adopting this library can keep an ordinary Django
+        alias alongside an async one. No async wrapper can be built for
+        such an alias, so the scope must not try to swap a connection for
+        it just because it is configured.
+        """
+        async_connections.settings["legacy"] = dict(
+            async_connections.settings[DEFAULT_DB_ALIAS],
+            ENGINE="django.db.backends.sqlite3",
+        )
+        try:
+
+            async def writer():
+                await TestModel.async_objects.acreate(name="mixed")
+                return await names()
+
+            self.assertEqual(await async_new_connection(writer()), ["mixed"])
+        finally:
+            # Before teardown, which walks every configured alias.
+            async_connections.settings.pop("legacy")


### PR DESCRIPTION
## Problem

`close_old_async_connections()` walks `async_connections.all()`. `all()` does not
just iterate — it *creates* a wrapper for every alias it finds uninitialized, and
`create_connection()` stamps each one with the calling task.

It runs as a `request_started` receiver. Django dispatches async receivers in a
`TaskGroup` child with a copied context and then `_restore_context()`s the changes
back into the sender's (`django/dispatch/dispatcher.py:41-66`), so that wrapper
lands in `ASGIHandler.handle()`'s context owned by a task that has already
finished. `validate_task_sharing()` then rejects the request's first query.

Reproduced on a vanilla project — Django 6.1, psycopg 3.3.4 + psycopg-pool,
uvicorn, `django-async-backend` 6.1.2 from PyPI, `INSTALLED_APPS =
["django_async_backend"]`, `MIDDLEWARE = []`, one view doing
`async_connections[DEFAULT_DB_ALIAS]` then `SELECT 1`:

```
req 1: HTTP 200 {"store_on_entry": ["default"], "query": "FAILED",
                 "error_type": "RuntimeError",
                 "error": "An async connection can only be used by the
                           task that created it..."}
```

Every request, from the first — `store_on_entry` is already populated before the
view runs a line.

Two further failures from the same call:

- `ASYNC_BACKEND_DISABLE_REQUEST_SIGNALS = True` gets the queries working, but
  nothing is released: a `max_size=3` pool dies on request 4 with `couldn't get a
  connection after 5.00 sec`.
- A project that keeps an ordinary Django alias alongside an async one gets
  `ConnectionDoesNotExist: The async connection 'legacy' doesn't exist.` on every
  request, because `all()` tries to build a wrapper for it.

## Why CI stayed green

Nothing was wrong when #10 merged. Task ownership (#77/#78) landed after it, and
before that a foreign-task wrapper was harmless. Two things then kept it
invisible:

- `tests/db/test_close_old_async_connections.py` mocked `async_connections.all`
  out entirely and asserted `mocked_all.assert_called_once_with()` — pinning the
  call signature at issue.
- `AsyncioTransactionTestCase.__init_subclass__` wraps every test method with
  `_refresh_connection_task_ownership_decorator`, which touches every alias and
  re-stamps `_task`. No test on that base class can observe foreign ownership.

## Fix

`all(initialized_only=True)`, and drop each wrapper from the store rather than
only closing it — `close()` leaves the wrapper and its owner in place, so one left
behind is still handed to whatever runs next in the context.

Two details:

- Every wrapper leaves the store before any close is awaited, and the closes run
  under one `gather`, so a connection that cannot be handed back neither strands
  nor leaks the aliases beside it. The first failure is still raised, as before.
- A wrapper inside an atomic block is closed but kept. `close()` turns it into a
  tombstone that refuses to reconnect; dropping it would put the rest of that
  block on a fresh connection outside its transaction, making a loud failure a
  silent one.

## On #24 and #25

`initialized_only` was dropped in #31 and reaffirmed in #10 to catch connections
created in `gather` children (#24), which live in the child's contextvar copy.
That reasoning no longer holds. Measured, pool `max_size=3`, two children per
iteration, releasing between iterations:

| release | iter 1 | iter 2 |
| --- | --- | --- |
| `all()` | ok | `RuntimeError` — the planted wrapper poisons the next round of children |
| `all(initialized_only=True)` | ok | pool exhausted — #24, unchanged |
| children in `async_new_connection()` | ok | 6/6 iterations, no leak |

`all()` never closed a child's connection: it builds a *fresh* wrapper in the
parent's context with `connection is None`, so the close is a no-op. It fails on
the same iteration as `initialized_only`, only louder.

And the pattern it was protecting is no longer a supported one. Per AGENTS.md,
fanning out with `gather` now raises unless each child opts into
`async_new_connection()` — which did not exist when #25 was written, and which
handles its own cleanup. Reaching the leak at all requires a parent that never
touched the database.

So this PR does not fix #24. It leaves it exactly where `all()` left it.

## Testing

`tests/test_request_signals.py` is folded into
`tests/db/test_close_old_async_connections.py`. The mocked tests are replaced by
ones that dispatch the real signals from `IsolatedAsyncioTestCase` — deliberately
not `AsyncioTransactionTestCase`, for the reason above — including the
synchronous `send()` that `HttpResponse.close()` performs on the normal ASGI
response path, which is how `request_finished` actually reaches a receiver for a
request that returns a response.

832 tests pass in default, `--reverse`, and shuffled order. Each decision is
mutation-tested:

| mutation | fails |
| --- | --- |
| `all()` instead of `initialized_only=True` | `test_does_not_open_aliases_this_context_never_used`, `test_ignores_an_alias_that_is_not_an_async_backend` |
| unconditional `del` | `test_keeps_a_wrapper_that_is_inside_a_transaction` |
| no `del` | 7 tests |
| close loop that aborts on the first failure | `test_closes_every_alias_even_when_one_fails` |

End to end, the same vanilla project against this branch: 8/8 requests OK, store
clean on entry every time, pool never exhausted.

## Deliberately not in this PR

- **`CONN_MAX_AGE`.** This closes unconditionally rather than via
  `close_if_unusable_or_obsolete()`, unchanged here. Worth its own look: with a
  per-context store a wrapper cannot survive to be reused, so persistent
  connections are unreachable and the `_old_` in the name has nothing left to
  decide.
- **`_new_connection_scope()`** calls unfiltered `async_connections.all()`
  (`db/new_connection.py:19,29`), so it can build throwaway wrappers for
  untouched aliases — the same shape of issue with a smaller blast radius.
- **Whether a failing close should propagate out of a signal receiver at all.**
  Behaviour is unchanged here; a single bad close still aborts request teardown.
- **Naming.** `close()` means `putconn` and `_old_` means nothing; a rename to
  something like `release_async_connections()` (with the old name kept as an
  alias, since the docs tell people to connect it manually) would be clearer, but
  does not belong in a bug fix.

## Summary by Sourcery

Release context-owned async connections safely without contaminating subsequent requests or touching unused database aliases.

Bug Fixes:
- Release only initialized async connections owned by the current context, preventing stale task ownership from breaking subsequent requests.
- Avoid creating wrappers for untouched or non-async database aliases during connection cleanup and temporary connection scopes.
- Ensure all connections are removed from the store before cleanup so failures do not strand other connections, while preserving transaction tombstones.

Enhancements:
- Update connection-scope handling to operate only on aliases that the context has initialized.
- Replace mocked cleanup tests with signal-driven coverage for async and synchronous request-finished dispatch, including mixed database configurations and transaction behavior.

Tests:
- Expand cleanup and connection-scope tests to cover stale ownership, alias filtering, cleanup failures, transaction safety, and real request signal integration.