### PR TITLE
test: add an ASGI gauntlet for the connection lifecycle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,3 +167,57 @@ jobs:
       run: |
         source .venv/bin/activate
         cd tests && python manage.py test
+
+  gauntlet:
+    name: ASGI gauntlet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres -d postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      id: setup-python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install and configure Poetry
+      uses: snok/install-poetry@v1
+      with:
+          version: 2.1.3
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: .venv
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install dependencies
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --with dev --no-interaction --no-root
+
+    - name: Install project
+      run: poetry install --no-interaction
+
+    - name: Run the gauntlet
+      run: |
+        source .venv/bin/activate
+        python gauntlet/run.py

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ upgrade_plan.*.md
 
 # claude
 .claude/plans/
+
+# Local gauntlet arms for an out-of-tree driver.
+gauntlet/arms_local.py

--- a/gauntlet/README.md
+++ b/gauntlet/README.md
@@ -17,7 +17,9 @@ unit-of-work boundary:
 - every open async alias is released, and an ordinary Django alias is
   left alone rather than being built;
 - after a release, the next task in the same context can open its own
-  connection — the case a worker or a mounted ASGI sub-app hits.
+  connection — the case a worker or a mounted ASGI sub-app hits;
+- requests in flight together are served correctly, and a pool queues
+  them rather than exceeding its size.
 
 ## Why it is not in `tests/`
 
@@ -44,6 +46,18 @@ poetry run python gauntlet/run.py
 Connection settings come from the usual `PG*` environment variables and
 default to the ones in `docker-compose.yml`. A non-zero exit status means
 an invariant broke; each line names which one.
+
+### Latency
+
+Database traffic is delayed by `LATENCY_MS` (2 by default), which widens
+the window in which two tasks can race for the same connection — where
+the bugs in this layer live. `LATENCY_MS=0` connects straight to
+Postgres.
+
+The delay comes from a small TCP proxy (`latency.py`), not from
+`tc`/netem: netem needs `NET_ADMIN`, and on loopback it would delay the
+driver's own HTTP as much as the database traffic. The proxy delays only
+what the application exchanges with Postgres, and needs no privileges.
 
 To point the gauntlet at a checkout other than the installed package —
 useful for confirming it still detects a regression you have a fix for:
@@ -86,7 +100,9 @@ a few things are deliberate:
 - **The server's output goes to a file, not a pipe.** A server that
   writes more than a pipe holds would block forever, which reads as a
   hang rather than a failure.
-- **The baseline is sampled until two reads agree**, because a pool fills
-  its minimum size in the background.
+- **The baseline is sampled until two reads agree**, and only after a
+  warm-up burst. A pool grows under load and keeps what it opened, so a
+  baseline read at `min_size` would see that growth later and call it a
+  leak.
 - **`--only` matching nothing, and a `--lib` without a package in it, are
   errors**, not silent successes.

--- a/gauntlet/README.md
+++ b/gauntlet/README.md
@@ -1,0 +1,92 @@
+# ASGI gauntlet
+
+A conformance harness for the connection lifecycle. Each arm boots a real
+ASGI server against a real Postgres and asserts what has to hold at a
+unit-of-work boundary:
+
+- a request starts with an empty connection store;
+- the connection a request opens is handed back when it ends;
+- this run's backend count returns to where it began;
+- both halves of the wiring release — `request_started` and
+  `request_finished` are asserted separately;
+- a child task may not use the connection its parent opened, and fan-out
+  through `async_new_connection()` works;
+- releasing while a transaction is open leaves the wrapper in place, so
+  the rest of the block fails loudly instead of quietly continuing on a
+  connection outside the transaction;
+- every open async alias is released, and an ordinary Django alias is
+  left alone rather than being built;
+- after a release, the next task in the same context can open its own
+  connection — the case a worker or a mounted ASGI sub-app hits.
+
+## Why it is not in `tests/`
+
+The Django test suite cannot see this class of bug.
+`AsyncioTransactionTestCase` re-stamps task ownership of every alias
+before each test method, which is exactly the state a lifecycle bug
+corrupts, and no test goes through a real server, so nothing exercises
+Django's own request signal dispatch.
+
+## Running it
+
+Start Postgres (`docker compose up postgres -d`), then:
+
+```sh
+lets gauntlet
+```
+
+or directly:
+
+```sh
+poetry run python gauntlet/run.py
+```
+
+Connection settings come from the usual `PG*` environment variables and
+default to the ones in `docker-compose.yml`. A non-zero exit status means
+an invariant broke; each line names which one.
+
+To point the gauntlet at a checkout other than the installed package —
+useful for confirming it still detects a regression you have a fix for:
+
+```sh
+poetry run python gauntlet/run.py --lib ../some-other-checkout
+poetry run python gauntlet/run.py --only pooled
+```
+
+## Arms
+
+| arm | what it covers |
+| --- | --- |
+| `pooled` | `OPTIONS["pool"]`, the recommended ASGI configuration. Asserts backends are actually reused |
+| `unpooled` | no pool: asserts a real connect and disconnect per request |
+| `multi-alias` | two async aliases plus an ordinary Django one |
+| `conn_max_age (unsupported)` | asserts `CONN_MAX_AGE` stays inert. Django's docs say persistent connections should be disabled under ASGI in favour of pooling, and honouring the setting here would leak a backend per request |
+| `pool + conn_max_age` | asserts the combination is still rejected |
+
+## Adding an arm out of tree
+
+A driver that lives outside this repository can be added without touching
+the committed matrix. Copy `arms_local.py.example` to `arms_local.py`
+(untracked) and list the arm there; it is skipped automatically when the
+driver is not importable.
+
+## How it avoids lying to you
+
+A harness that passes while the library is broken is worse than none, so
+a few things are deliberate:
+
+- **Backends are counted by `application_name`, not by database.** Each
+  run stamps its connections with a unique name and counts only those,
+  so another client on the same Postgres cannot mask a leak or invent
+  one.
+- **Each arm gets an ephemeral port and a nonce.** `/ping` echoes the
+  nonce and the path the server imported `django_async_backend` from, and
+  the driver refuses to continue if either is not its own. Otherwise a
+  stray server left on a fixed port would be tested instead.
+- **The server's output goes to a file, not a pipe.** A server that
+  writes more than a pipe holds would block forever, which reads as a
+  hang rather than a failure.
+- **The baseline is sampled until two reads agree**, because a pool fills
+  its minimum size in the background.
+- **`--only` matching nothing, and a `--lib` without a package in it, are
+  errors**, not silent successes.

--- a/gauntlet/app.py
+++ b/gauntlet/app.py
@@ -1,0 +1,309 @@
+"""One ASGI app, parameterised by environment, for the gauntlet driver.
+
+Every arm of the matrix runs this same app; only the environment differs.
+The views report the invariants the driver asserts on, so a failure names
+the broken invariant rather than only a status code.
+
+Connections carry a per-run ``application_name`` so the driver can count
+its own server's backends and nothing else. Without that, any other
+client on the same database moves the count and a leak hides in the noise.
+"""
+
+import asyncio
+import json
+import os
+
+import django
+from django.conf import settings
+
+DEFAULT_ENGINE = "django_async_backend.db.backends.postgresql"
+
+NONCE = os.environ.get("GAUNTLET_NONCE", "gauntlet")
+POOL_MAX = int(os.environ.get("POOL_MAX", "0"))
+CONN_MAX_AGE = int(os.environ.get("CONN_MAX_AGE", "0"))
+EXTRA_ALIASES = os.environ.get("EXTRA_ALIASES") == "1"
+
+
+def postgres_alias():
+    options = {"application_name": NONCE}
+    if POOL_MAX:
+        options["pool"] = {"min_size": 1, "max_size": POOL_MAX, "timeout": 5}
+    return {
+        "ENGINE": os.environ.get("ENGINE", DEFAULT_ENGINE),
+        "NAME": os.environ.get("PGDATABASE", "postgres"),
+        "USER": os.environ.get("PGUSER", "postgres"),
+        "PASSWORD": os.environ.get("PGPASSWORD", "postgres"),
+        "HOST": os.environ.get("PGHOST", "localhost"),
+        "PORT": os.environ.get("PGPORT", "5432"),
+        "CONN_MAX_AGE": CONN_MAX_AGE,
+        "OPTIONS": options,
+    }
+
+
+databases = {"default": postgres_alias()}
+if EXTRA_ALIASES:
+    # A second async alias, to catch a release that only handles one, and
+    # an ordinary Django alias, which has no async wrapper to build at all.
+    databases["other"] = postgres_alias()
+    databases["legacy"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+
+settings.configure(
+    SECRET_KEY="gauntlet",
+    DEBUG=False,
+    ALLOWED_HOSTS=["*"],
+    USE_TZ=True,
+    INSTALLED_APPS=["django_async_backend"],
+    MIDDLEWARE=[],
+    ROOT_URLCONF=__name__,
+    DATABASES=databases,
+    LOGGING={
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {"console": {"class": "logging.StreamHandler"}},
+        "root": {"handlers": ["console"], "level": "ERROR"},
+    },
+)
+django.setup()
+
+from django.core import signals  # noqa: E402
+from django.core.asgi import get_asgi_application  # noqa: E402
+from django.db import DEFAULT_DB_ALIAS  # noqa: E402
+from django.http import HttpResponse  # noqa: E402
+from django.urls import path  # noqa: E402
+
+import django_async_backend  # noqa: E402
+from django_async_backend.db import (  # noqa: E402
+    async_connections,
+    async_new_connection,
+    close_old_async_connections,
+)
+from django_async_backend.db.transaction import async_atomic  # noqa: E402
+
+
+def stored():
+    """Aliases the current context holds a connection wrapper for."""
+    return sorted(
+        conn.alias for conn in async_connections.all(initialized_only=True)
+    )
+
+
+async def scalar(sql, params=None, alias=DEFAULT_DB_ALIAS):
+    connection = async_connections[alias]
+    async with await connection.cursor() as cursor:
+        await cursor.execute(sql, params)
+        return (await cursor.fetchone())[0]
+
+
+def reply(report):
+    return HttpResponse(json.dumps(report), content_type="application/json")
+
+
+def attempt(report, key="ok"):
+    """Record whether a block succeeded, without letting it 500."""
+
+    class Attempt:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            report[key] = exc is None
+            if exc is not None:
+                report["error"] = type(exc).__name__
+                report["detail"] = str(exc)[:160]
+            return True
+
+    return Attempt()
+
+
+async def one_query(request):
+    """The ordinary case: one unit of work, one connection."""
+    report = {"store_on_entry": stored()}
+    async with attempt(report):
+        report["pid"] = await scalar("SELECT pg_backend_pid()")
+    return reply(report)
+
+
+async def fan_out_bare(request):
+    """Fan-out with no opt-in, which a child is not allowed to do."""
+    report = {"store_on_entry": stored()}
+    await scalar("SELECT 1")
+    results = await asyncio.gather(
+        scalar("SELECT 1"), scalar("SELECT 1"), return_exceptions=True
+    )
+    report["children"] = [
+        type(r).__name__ if isinstance(r, BaseException) else "ok"
+        for r in results
+    ]
+    return reply(report)
+
+
+async def fan_out_opted_in(request):
+    """Fan-out through async_new_connection, which is the way to do it."""
+
+    async def child():
+        async with async_new_connection():
+            return await scalar("SELECT 1")
+
+    report = {}
+    results = await asyncio.gather(child(), child(), return_exceptions=True)
+    report["children"] = [
+        type(r).__name__ if isinstance(r, BaseException) else "ok"
+        for r in results
+    ]
+    return reply(report)
+
+
+async def transaction(request):
+    """A request whose work happens inside a transaction."""
+    report = {"store_on_entry": stored()}
+    async with attempt(report):
+        async with async_atomic():
+            report["pid"] = await scalar("SELECT pg_backend_pid()")
+    return reply(report)
+
+
+async def release_on_signal(request, which):
+    """Dispatch one request signal with a connection already open.
+
+    Each half of the wiring in apps.py is asserted separately. A release
+    that only runs on one of the two signals leaves this store dirty.
+    """
+    signal = {
+        "started": signals.request_started,
+        "finished": signals.request_finished,
+    }[which]
+    connection = async_connections[DEFAULT_DB_ALIAS]
+    await connection.ensure_connection()
+    report = {"store_before": stored()}
+    async with attempt(report):
+        if signal is signals.request_started:
+            await signal.asend(sender=None, scope={})
+        else:
+            await signal.asend(sender=None)
+    report["store_after"] = stored()
+    report["connection_closed"] = connection.connection is None
+    return reply(report)
+
+
+async def boundary_then_new_task(request):
+    """A non-HTTP boundary, where releasing has to do both halves.
+
+    A worker or a mounted ASGI sub-app releases at the end of a unit of
+    work and then runs the next one in a task of its own, inside the same
+    context. Closing the connection is not enough there: a wrapper left
+    in the store belongs to the task that released it, and the next task
+    is not allowed to use it.
+    """
+    await scalar("SELECT 1")
+    await close_old_async_connections()
+    report = {"store_after_release": stored()}
+
+    async def next_unit_of_work():
+        # A worker releases inside its own task, the only context that
+        # can see the connection it opened.
+        try:
+            return await scalar("SELECT pg_backend_pid()")
+        finally:
+            await close_old_async_connections()
+
+    async with attempt(report):
+        report["pid"] = await asyncio.create_task(next_unit_of_work())
+    return reply(report)
+
+
+async def atomic_boundary(request):
+    """A release that happens while a transaction is open.
+
+    close() turns such a wrapper into a tombstone that refuses to
+    reconnect. The release has to leave it in the store: replacing it
+    would put the rest of the block on a fresh connection outside the
+    transaction, and the block would report success.
+    """
+    report = {}
+    async with attempt(report, key="block_completed"):
+        async with async_atomic():
+            connection = async_connections[DEFAULT_DB_ALIAS]
+            await connection.ensure_connection()
+            await close_old_async_connections()
+            report["same_wrapper"] = (
+                async_connections[DEFAULT_DB_ALIAS] is connection
+            )
+            inner = {}
+            async with attempt(inner, key="query_succeeded"):
+                await scalar("SELECT 1")
+            report["query_after_release_succeeded"] = inner["query_succeeded"]
+    return reply(report)
+
+
+async def two_aliases(request):
+    """Release with more than one async alias open.
+
+    Also covers an ordinary Django alias being configured: no async
+    wrapper can be built for it, so an untouched one must be left alone.
+    """
+    await scalar("SELECT 1")
+    await scalar("SELECT 1", alias="other")
+    report = {"store_before": stored()}
+    async with attempt(report):
+        await close_old_async_connections()
+    report["store_after"] = stored()
+    return reply(report)
+
+
+async def signal_started(request):
+    return await release_on_signal(request, "started")
+
+
+async def signal_finished(request):
+    return await release_on_signal(request, "finished")
+
+
+async def ping(request):
+    """Liveness, plus proof of which server and which library answered.
+
+    Must not touch the database, so the driver can wait for a server
+    whose database configuration is deliberately invalid.
+    """
+    return reply(
+        {
+            "nonce": NONCE,
+            "library": django_async_backend.__file__,
+            "aliases": sorted(settings.DATABASES),
+        }
+    )
+
+
+async def backends(request):
+    """How many backends this run has open, excluding the one asking.
+
+    Reports a failure rather than raising, so a broken arm gives the
+    driver a diagnosis instead of a 500.
+    """
+    report = {}
+    async with attempt(report):
+        report["backends"] = await scalar(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE application_name = %s AND pid <> pg_backend_pid()",
+            (NONCE,),
+        )
+    return reply(report)
+
+
+urlpatterns = [
+    path("ping", ping),
+    path("backends", backends),
+    path("fanout/bare", fan_out_bare),
+    path("fanout/opted-in", fan_out_opted_in),
+    path("transaction", transaction),
+    path("boundary", boundary_then_new_task),
+    path("atomic-boundary", atomic_boundary),
+    path("two-aliases", two_aliases),
+    path("signal/started", signal_started),
+    path("signal/finished", signal_finished),
+    path("", one_query),
+]
+
+application = get_asgi_application()

--- a/gauntlet/arms_local.py.example
+++ b/gauntlet/arms_local.py.example
@@ -1,0 +1,21 @@
+"""Extra gauntlet arms for a driver that lives outside this repository.
+
+Copy to ``arms_local.py`` (untracked) and edit. Each arm is a name and the
+environment the app is started with. ``ENGINE`` selects the backend;
+``REQUIRES`` names a module that must be importable for the arm to run,
+so it is skipped rather than failed when the driver is absent.
+"""
+
+ARMS = [
+    (
+        "some-other-driver",
+        {
+            "ENGINE": "some_package.django_backend",
+            "REQUIRES": "some_package",
+        },
+    ),
+]
+
+# Arms whose configuration the driver is expected to reject, mapped to the
+# exception name it should raise.
+MUST_REFUSE = {}

--- a/gauntlet/latency.py
+++ b/gauntlet/latency.py
@@ -1,0 +1,94 @@
+"""A TCP proxy that holds Postgres responses back by a fixed delay.
+
+Injecting latency widens the window in which two tasks can race for the
+same connection, which is where the concurrency bugs in this layer live.
+`tc`/netem would be the obvious tool, but it needs NET_ADMIN and, on
+loopback, would delay the driver's own HTTP as much as the database
+traffic. This delays only what the application sends to and receives from
+Postgres, from an ordinary unprivileged process.
+
+The delay is applied to each chunk travelling from the server back to the
+client, so a query costs roughly one delay more than it otherwise would,
+and the task awaiting it holds its connection for that much longer.
+"""
+
+import asyncio
+import threading
+
+
+class LatencyProxy:
+    """Forward 127.0.0.1:<port> to an upstream, delaying responses."""
+
+    def __init__(self, host, port, delay_seconds):
+        self.host = host
+        self.port = int(port)
+        self.delay = delay_seconds
+        self.local_port = None
+        self._loop = None
+        self._server = None
+        self._thread = None
+        self._ready = threading.Event()
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=10):
+            raise RuntimeError("latency proxy did not start")
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+        return False
+
+    def _run(self):
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._listen())
+        self._ready.set()
+        try:
+            self._loop.run_forever()
+        finally:
+            self._loop.run_until_complete(self._close())
+            self._loop.close()
+
+    async def _listen(self):
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.local_port = self._server.sockets[0].getsockname()[1]
+
+    async def _close(self):
+        self._server.close()
+        await self._server.wait_closed()
+
+    async def _handle(self, client_reader, client_writer):
+        try:
+            server_reader, server_writer = await asyncio.open_connection(
+                self.host, self.port
+            )
+        except OSError:
+            client_writer.close()
+            return
+        try:
+            await asyncio.gather(
+                self._pump(client_reader, server_writer, 0),
+                self._pump(server_reader, client_writer, self.delay),
+                return_exceptions=True,
+            )
+        finally:
+            for writer in (client_writer, server_writer):
+                writer.close()
+
+    async def _pump(self, reader, writer, delay):
+        try:
+            while True:
+                chunk = await reader.read(65536)
+                if not chunk:
+                    break
+                if delay:
+                    await asyncio.sleep(delay)
+                writer.write(chunk)
+                await writer.drain()
+        except (OSError, asyncio.IncompleteReadError):
+            pass

--- a/gauntlet/run.py
+++ b/gauntlet/run.py
@@ -1,0 +1,473 @@
+"""Run the ASGI gauntlet across every supported connection setting.
+
+Each arm boots a real ASGI server against a real Postgres and asserts the
+invariants that matter at a unit-of-work boundary: a request starts with
+an empty connection store, the connection it opens is handed back, and
+this run's backend count returns to where it began.
+
+The library's own test suite cannot cover this. AsyncioTransactionTestCase
+re-stamps task ownership of every alias before each test method, and no
+test goes through a real server, so bugs that live in the request
+lifecycle are invisible to it.
+
+Usage::
+
+    python gauntlet/run.py
+    python gauntlet/run.py --lib /path/to/a/checkout --only pooled
+
+``--lib`` puts a checkout of ``django_async_backend`` first on the app's
+path, so the same gauntlet can be pointed at a branch or at a mutant to
+check that it still detects a regression.
+
+Postgres is read from the usual PG* environment variables, defaulting to
+the one in docker-compose.yml.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+HERE = pathlib.Path(__file__).parent
+
+# Django's documentation says persistent connections should be disabled
+# under ASGI in favour of the backend's own pooling, and this library
+# requires ASGI. The conn_max_age arm is therefore a negative one: it
+# asserts the setting stays inert, because honouring it would leak a
+# backend per request.
+ARMS = [
+    ("pooled", {"POOL_MAX": "3"}),
+    ("unpooled", {}),
+    ("multi-alias", {"EXTRA_ALIASES": "1"}),
+    ("conn_max_age (unsupported)", {"CONN_MAX_AGE": "60"}),
+    ("pool + conn_max_age", {"POOL_MAX": "3", "CONN_MAX_AGE": "60"}),
+]
+
+# Arms whose configuration the library is expected to reject. The pool
+# property raises lazily, so the server starts and every request fails.
+MUST_REFUSE = {"pool + conn_max_age": "ImproperlyConfigured"}
+
+# Arms may be added out of tree for a driver that lives elsewhere; see
+# arms_local.py.example.
+try:
+    import arms_local
+
+    ARMS += arms_local.ARMS
+    MUST_REFUSE.update(getattr(arms_local, "MUST_REFUSE", {}))
+except ImportError:
+    pass
+
+BOOT_TIMEOUT = 30.0
+PROBE_TIMEOUT = 2.0
+REQUEST_TIMEOUT = 20.0
+
+_base = None
+
+
+class Failure(Exception):
+    """An invariant this gauntlet exists to protect was broken."""
+
+
+def emit(line):
+    sys.stdout.write(f"{line}\n")
+    sys.stdout.flush()
+
+
+def get(path, timeout=REQUEST_TIMEOUT):
+    url = f"{_base}{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        raise Failure(f"{path} returned HTTP {exc.code}") from exc
+
+
+def free_port():
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def start(env, lib, port, nonce, log):
+    path = [str(HERE)]
+    if lib:
+        path.insert(0, str(lib))
+    child_env = {
+        **os.environ,
+        **env,
+        "GAUNTLET_NONCE": nonce,
+        "PYTHONPATH": os.pathsep.join(path),
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    # A file, not a pipe: a server that writes more than the pipe holds
+    # would block forever, which reads as a hang rather than a failure.
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "app:application",
+        ],
+        cwd=HERE,
+        env=child_env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def wait_until_listening(process, port):
+    """Wait for the server to accept connections.
+
+    Readiness is a TCP connect rather than a request, because a bug in
+    the release path fails *every* request -- request_started runs before
+    the view, so even an endpoint that touches no database returns 500.
+    Probing with HTTP would report a server that started perfectly well
+    as never having booted.
+    """
+    deadline = time.monotonic() + BOOT_TIMEOUT
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            return False
+        try:
+            with socket.create_connection(
+                ("127.0.0.1", port), timeout=PROBE_TIMEOUT
+            ):
+                return True
+        except OSError:
+            time.sleep(0.25)
+    return False
+
+
+def ping_when_ready(seconds=8.0):
+    """The first successful /ping, or the last thing that went wrong.
+
+    A connectable port does not mean the app has finished importing, so
+    a few failures here are ordinary. Persistent ones are the answer.
+    """
+    deadline = time.monotonic() + seconds
+    problem = None
+    while time.monotonic() < deadline:
+        try:
+            return get("/ping", timeout=PROBE_TIMEOUT), None
+        except (Failure, urllib.error.URLError, OSError) as exc:
+            problem = exc
+            time.sleep(0.25)
+    return None, problem
+
+
+def stop(process):
+    if process.poll() is None:
+        process.send_signal(signal.SIGINT)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+
+
+def tail(log_path, lines=6):
+    text = log_path.read_text(errors="replace").strip().splitlines()
+    return " | ".join(line[:120] for line in text[-lines:]) or "no output"
+
+
+def count_backends():
+    body = get("/backends")
+    if "backends" not in body:
+        detail = f"{body.get('error')} {body.get('detail', '')}".strip()
+        raise Failure(f"cannot count backends: {detail}")
+    return body["backends"]
+
+
+def settle_backends(timeout=8.0):
+    """Sample until two reads agree.
+
+    A pool fills its minimum size in the background, so the first read
+    after boot can be one short of the resting count.
+    """
+    previous = None
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        current = count_backends()
+        if current == previous:
+            return current
+        previous = current
+        time.sleep(0.25)
+    return previous
+
+
+def check(condition, message):
+    if not condition:
+        raise Failure(message)
+
+
+def scenario_sequential(findings, env):
+    """Ordinary requests: clean slate in, connection back out.
+
+    The number of distinct backends also says whether pooling is doing
+    anything: reusing them when a pool is configured, and not when the
+    connection is genuinely closed each request.
+    """
+    pids = set()
+    for i in range(1, 6):
+        body = get("/")
+        check(body["ok"], f"request {i} failed: {body.get('detail')}")
+        check(
+            body["store_on_entry"] == [],
+            f"request {i} began with {body['store_on_entry']} in the store",
+        )
+        pids.add(body["pid"])
+    findings["backend ids over 5 requests"] = len(pids)
+    if env.get("POOL_MAX"):
+        check(
+            len(pids) < 5,
+            f"pooling reused nothing: {len(pids)} backends for 5 requests",
+        )
+    else:
+        check(
+            len(pids) > 1,
+            "every request got the same backend with no pool configured",
+        )
+
+
+def scenario_signals(findings, env):
+    """Each half of the wiring in apps.py, asserted separately."""
+    for which in ("started", "finished"):
+        body = get(f"/signal/{which}")
+        check(body["ok"], f"request_{which} raised: {body.get('detail')}")
+        check(
+            body["store_after"] == [],
+            f"request_{which} left {body['store_after']} in the store",
+        )
+        check(
+            body["connection_closed"],
+            f"request_{which} did not hand the connection back",
+        )
+
+
+def scenario_fan_out_bare(findings, env):
+    """A child task may not use the connection its parent opened."""
+    children = get("/fanout/bare")["children"]
+    findings["bare fan-out"] = ",".join(children)
+    check(
+        "ok" not in children,
+        f"a child task shared its parent's connection: {children}",
+    )
+
+
+def scenario_fan_out_opted_in(findings, env):
+    """Fan-out through async_new_connection has to work."""
+    children = get("/fanout/opted-in")["children"]
+    check(children == ["ok", "ok"], f"opted-in fan-out gave {children}")
+
+
+def scenario_transaction(findings, env):
+    """A transaction must not poison the request that follows it."""
+    body = get("/transaction")
+    check(body["ok"], f"transaction failed: {body.get('detail')}")
+    body = get("/")
+    check(
+        body["store_on_entry"] == [],
+        f"request after a transaction began with {body['store_on_entry']}",
+    )
+    check(body["ok"], f"request after a transaction failed: {body!r}")
+
+
+def scenario_boundary(findings, env):
+    """After a release, the next task in the same context must be able to
+    open a connection of its own -- the case a worker or sub-app hits."""
+    body = get("/boundary")
+    check(
+        body["store_after_release"] == [],
+        f"release left {body['store_after_release']} in the store",
+    )
+    detail = f"{body.get('error')} {body.get('detail', '')}".strip()
+    check(body["ok"], f"the next task could not query: {detail}")
+
+
+def scenario_atomic_boundary(findings, env):
+    """Releasing inside a transaction must fail loudly afterwards, not
+    quietly continue on a connection outside it."""
+    body = get("/atomic-boundary")
+    check(
+        body.get("same_wrapper") is True,
+        "a release inside a transaction replaced the connection",
+    )
+    check(
+        body.get("query_after_release_succeeded") is False,
+        "a query inside the block succeeded after the release, so the "
+        "rest of the transaction ran on another connection",
+    )
+
+
+def scenario_two_aliases(findings, env):
+    """Every open async alias is released, and a non-async one is left
+    alone rather than being built."""
+    if env.get("EXTRA_ALIASES") != "1":
+        return
+    body = get("/two-aliases")
+    check(body["ok"], f"releasing two aliases raised: {body.get('detail')}")
+    check(
+        body["store_before"] == ["default", "other"],
+        f"expected both aliases open, got {body['store_before']}",
+    )
+    check(
+        body["store_after"] == [],
+        f"release left {body['store_after']} in the store",
+    )
+
+
+SCENARIOS = [
+    ("sequential", scenario_sequential),
+    ("request signals", scenario_signals),
+    ("bare fan-out", scenario_fan_out_bare),
+    ("opted-in fan-out", scenario_fan_out_opted_in),
+    ("transaction", scenario_transaction),
+    ("non-HTTP boundary", scenario_boundary),
+    ("atomic boundary", scenario_atomic_boundary),
+    ("two aliases", scenario_two_aliases),
+]
+
+
+def identify(nonce, port, lib, findings, log_path):
+    """Prove we are talking to our own child, on the library we chose.
+
+    A stray server on the port, or a --lib that silently did not take,
+    would otherwise be tested instead and could report a false pass.
+    """
+    hello, problem = ping_when_ready()
+    if hello is None:
+        # Listening but not answering: a broken request path, not a
+        # server that failed to start.
+        return "FAILED", {"ping": str(problem), "log": tail(log_path, 3)}
+    if hello.get("nonce") != nonce:
+        return "FAILED", {"port": f"{port} answered by another server"}
+    if lib and str(lib.resolve()) not in hello.get("library", ""):
+        return "FAILED", {"library": hello.get("library")}
+    findings["aliases"] = len(hello.get("aliases", []))
+    return None
+
+
+def refusal(expected):
+    body = get("/")
+    if body.get("error") == expected:
+        return "expected refusal", {"raised": expected}
+    return "FAILED", {"expected": expected, "got": repr(body)[:110]}
+
+
+def run_scenarios(findings, env):
+    for label, scenario in SCENARIOS:
+        try:
+            scenario(findings, env)
+        except Failure as exc:
+            return "FAILED", {**findings, label: f"FAILED: {exc}"}
+    return None
+
+
+def run_arm(name, env, lib):
+    global _base
+    findings = {}
+    requires = env.pop("REQUIRES", None)
+    if requires:
+        probe = subprocess.run(
+            [sys.executable, "-c", f"import {requires}"],
+            capture_output=True,
+            check=False,
+        )
+        if probe.returncode != 0:
+            return "skipped", {"missing": requires}
+
+    nonce = f"gauntlet-{uuid.uuid4().hex[:12]}"
+    port = free_port()
+    _base = f"http://127.0.0.1:{port}"
+    with tempfile.TemporaryDirectory() as workspace:
+        log_path = pathlib.Path(workspace) / "server.log"
+        with log_path.open("w") as log:
+            process = start(env, lib, port, nonce, log)
+        try:
+            if not wait_until_listening(process, port):
+                return "FAILED TO BOOT", {"log": tail(log_path)}
+
+            wrong = identify(nonce, port, lib, findings, log_path)
+            if wrong:
+                return wrong
+
+            expected = MUST_REFUSE.get(name)
+            if expected:
+                return refusal(expected)
+
+            baseline = settle_backends()
+            broken = run_scenarios(findings, env)
+            if broken:
+                return broken
+
+            after = settle_backends()
+            findings["backends"] = f"{baseline} -> {after}"
+            if after > baseline:
+                return "LEAK", findings
+            return "ok", findings
+        finally:
+            stop(process)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--lib",
+        type=pathlib.Path,
+        default=None,
+        help="checkout of django_async_backend to test instead of the "
+        "installed one",
+    )
+    parser.add_argument(
+        "--only", default=None, help="run only arms matching this substring"
+    )
+    args = parser.parse_args()
+
+    if args.lib:
+        package = args.lib / "django_async_backend"
+        if not package.is_dir():
+            emit(f"--lib has no django_async_backend directory: {args.lib}")
+            return 2
+        emit(f"library under test: {args.lib.resolve()}")
+
+    selected = [
+        (name, env) for name, env in ARMS if not args.only or args.only in name
+    ]
+    if not selected:
+        emit(
+            f"--only {args.only!r} matched none of: "
+            + ", ".join(name for name, _ in ARMS)
+        )
+        return 2
+
+    failed = 0
+    for name, env in selected:
+        try:
+            verdict, findings = run_arm(name, dict(env), args.lib)
+        except Failure as exc:
+            verdict, findings = "FAILED", {"error": str(exc)}
+        except Exception as exc:  # noqa: BLE001 - report, never crash
+            verdict, findings = "ERROR", {type(exc).__name__: str(exc)[:140]}
+        detail = "; ".join(f"{k}: {v}" for k, v in findings.items())
+        emit(f"{verdict:>18}  {name:<28} {detail}")
+        if verdict not in ("ok", "expected refusal", "skipped"):
+            failed = 1
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gauntlet/run.py
+++ b/gauntlet/run.py
@@ -24,6 +24,7 @@ the one in docker-compose.yml.
 """
 
 import argparse
+import concurrent.futures
 import json
 import os
 import pathlib
@@ -36,6 +37,9 @@ import time
 import urllib.error
 import urllib.request
 import uuid
+from contextlib import ExitStack
+
+from latency import LatencyProxy
 
 HERE = pathlib.Path(__file__).parent
 
@@ -65,6 +69,15 @@ try:
     MUST_REFUSE.update(getattr(arms_local, "MUST_REFUSE", {}))
 except ImportError:
     pass
+
+# Database latency, injected by a proxy in front of Postgres. A couple of
+# milliseconds is enough to widen the window in which two tasks race for
+# the same connection, and costs little; set 0 to connect directly.
+LATENCY_MS = float(os.environ.get("LATENCY_MS", "2"))
+
+# How many requests the concurrency scenario runs at once. Deliberately
+# more than the pooled arm's max_size, so the pool has to queue.
+CONCURRENCY = 8
 
 BOOT_TIMEOUT = 30.0
 PROBE_TIMEOUT = 2.0
@@ -209,6 +222,26 @@ def settle_backends(timeout=8.0):
     return previous
 
 
+def burst(count=None):
+    """Issue several requests at once and return their bodies."""
+    count = count or CONCURRENCY
+    with concurrent.futures.ThreadPoolExecutor(count) as pool:
+        return list(pool.map(lambda _: get("/"), range(count)))
+
+
+def warm_up():
+    """Drive the pool to its working size before the baseline is taken.
+
+    A pool grows under load and keeps what it opened, so a baseline read
+    while it is still at min_size would see that growth later and call it
+    a leak. Failures here are left to the scenarios to diagnose.
+    """
+    try:
+        burst()
+    except Failure:
+        pass
+
+
 def check(condition, message):
     if not condition:
         raise Failure(message)
@@ -330,8 +363,38 @@ def scenario_two_aliases(findings, env):
     )
 
 
+def scenario_concurrent(findings, env):
+    """Requests in flight together, more than a pool can serve at once.
+
+    Nothing else here makes two requests overlap, so this is the only
+    scenario that exercises the lock around acquiring a connection, and
+    the only one where a pool has to make callers wait.
+    """
+    bodies = burst()
+
+    for i, body in enumerate(bodies, start=1):
+        check(
+            body["ok"], f"concurrent request {i} failed: {body.get('detail')}"
+        )
+        check(
+            body["store_on_entry"] == [],
+            f"concurrent request {i} began with {body['store_on_entry']}",
+        )
+    pids = {body["pid"] for body in bodies}
+    findings[f"backends for {CONCURRENCY} at once"] = len(pids)
+    limit = env.get("POOL_MAX")
+    if limit:
+        # close() hands a pooled connection back rather than dropping it,
+        # so a burst cannot have touched more backends than the pool holds.
+        check(
+            len(pids) <= int(limit),
+            f"{len(pids)} backends for a pool of {limit}",
+        )
+
+
 SCENARIOS = [
     ("sequential", scenario_sequential),
+    ("concurrent", scenario_concurrent),
     ("request signals", scenario_signals),
     ("bare fan-out", scenario_fan_out_bare),
     ("opted-in fan-out", scenario_fan_out_opted_in),
@@ -377,6 +440,24 @@ def run_scenarios(findings, env):
     return None
 
 
+def database_env(stack):
+    """Where the app should look for Postgres.
+
+    With latency enabled that is a proxy in front of it, so only the
+    database traffic is delayed and no privileges are needed.
+    """
+    if not LATENCY_MS:
+        return {}
+    proxy = stack.enter_context(
+        LatencyProxy(
+            os.environ.get("PGHOST", "localhost"),
+            os.environ.get("PGPORT", "5432"),
+            LATENCY_MS / 1000.0,
+        )
+    )
+    return {"PGHOST": "127.0.0.1", "PGPORT": str(proxy.local_port)}
+
+
 def run_arm(name, env, lib):
     global _base
     findings = {}
@@ -393,7 +474,9 @@ def run_arm(name, env, lib):
     nonce = f"gauntlet-{uuid.uuid4().hex[:12]}"
     port = free_port()
     _base = f"http://127.0.0.1:{port}"
-    with tempfile.TemporaryDirectory() as workspace:
+    with ExitStack() as stack:
+        env = dict(env, **database_env(stack))
+        workspace = stack.enter_context(tempfile.TemporaryDirectory())
         log_path = pathlib.Path(workspace) / "server.log"
         with log_path.open("w") as log:
             process = start(env, lib, port, nonce, log)
@@ -409,6 +492,7 @@ def run_arm(name, env, lib):
             if expected:
                 return refusal(expected)
 
+            warm_up()
             baseline = settle_backends()
             broken = run_scenarios(findings, env)
             if broken:

--- a/lets.yaml
+++ b/lets.yaml
@@ -94,6 +94,13 @@ commands:
       - manage.py
       - test
 
+  gauntlet:
+    group: Tests
+    description: Run the ASGI connection-lifecycle gauntlet (docker postgres)
+    depends:
+      - _test_database
+    cmd: poetry run python gauntlet/run.py
+
   test_django:
     group: Tests
     description: Run Django's own test suite against the async backend (docker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ exclude_dirs = [
   "env",
   ".cache",
   "tests",
+  "gauntlet",
   ".mypy_cache",
   ".django",
   "django_async_backend/db/models/query.py",


### PR DESCRIPTION
## Note on this PR's own CI

The gauntlet fails on `main`, and that red run is the point: `main` has the bug
#82 fixes, and this is what catches it.

```
FAILED  pooled       cannot count backends: RuntimeError An async connection
                     can only be used by the task that created it
FAILED  multi-alias  ConnectionDoesNotExist: The async connection 'legacy'
                     doesn't exist
```

With both commits from #82 it is green on every arm. Pointed at nine variants
of the library via `--lib`, one mutation each, it goes red on all eight broken
ones — release skipped on one signal, closing without dropping from the store,
dropping without closing, dropping a wrapper inside an atomic block, releasing
only the default alias, `validate_task_sharing()` made a no-op, and pooling
silently degraded to connect-per-request — each with a named scenario, not a
bare exit code.

The second failure above is how #82 grew its second commit:
`_new_connection_scope()` walks the same unfiltered `all()`, so
`async_new_connection()` cannot be used at all in a project that keeps an
ordinary Django alias alongside an async one. The suite cannot reach that,
because `tests/settings.py` configures async aliases only.

## Summary by Sourcery

Add a real-server ASGI gauntlet to verify connection lifecycle behavior and prevent leaks across request and task boundaries.

New Features:
- Add an ASGI connection-lifecycle gauntlet that runs real servers against PostgreSQL across pooled, unpooled, multi-alias, and connection-age configurations.

Enhancements:
- Validate request-boundary cleanup, signal handling, task isolation, transaction safety, alias release, backend reuse, and leak detection outside the Django unit-test suite.

CI:
- Run the ASGI gauntlet in CI with Python 3.12 and a PostgreSQL service.

Documentation:
- Document how to run, configure, extend, and interpret the ASGI gauntlet.

Tests:
- Add comprehensive integration coverage for ASGI connection lifecycle invariants and expected configuration refusal.

## Summary by Sourcery

Introduce a real-server ASGI gauntlet to validate connection lifecycle behavior and detect leaks across request and task boundaries.

New Features:
- Add a real-server ASGI connection-lifecycle conformance harness covering pooled, unpooled, multi-alias, and persistent-connection configurations.

Enhancements:
- Verify request cleanup, signal handling, task isolation, transaction safety, alias release, backend reuse, and connection leak invariants outside the Django unit-test suite.

CI:
- Run the ASGI gauntlet in CI against Python 3.12 and PostgreSQL.

Documentation:
- Document how to run, configure, extend, and interpret the ASGI gauntlet.

Tests:
- Add integration scenarios for lifecycle boundaries, fan-out, transactions, aliases, backend reuse, leak detection, and rejected configurations.

## Summary by Sourcery

Introduce a real-server ASGI gauntlet to enforce connection lifecycle invariants and detect leaks across request and task boundaries.

New Features:
- Add a real-server ASGI connection-lifecycle conformance harness covering pooled, unpooled, multi-alias, and persistent-connection configurations.

Enhancements:
- Verify connection cleanup, task isolation, transaction safety, signal handling, alias handling, backend reuse, concurrency, and leak detection at request and task boundaries.

CI:
- Run the ASGI gauntlet in CI with Python 3.12 and a PostgreSQL service.

Documentation:
- Document how to run, configure, extend, and interpret the ASGI gauntlet.

Tests:
- Add integration scenarios for lifecycle boundaries, fan-out, transactions, aliases, pooling, leak detection, and rejected configurations.