### PR TITLE
fix: release only the connections a context opened v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ async with await connection.cursor() as cursor:
 > alias, and every ORM and cursor call in that task takes turns on it — so
 > awaiting several queries in a row does not make them run concurrently.
 >
-> The connection is owned by the task that created it, so you cannot fan out
+> The connection is owned by the task that first used it, so you cannot fan out
 > onto it either: using it from another task — `asyncio.create_task()`,
 > `asyncio.gather()`, `asyncio.TaskGroup` — raises `RuntimeError`. Wrapping the
 > fan-out in a single `async_atomic()` block does **not** make it safe. To run

--- a/UPSTREAMING.md
+++ b/UPSTREAMING.md
@@ -8,3 +8,4 @@ Issues that need to be addressed before this library can be merged into Django's
 - acreate does not yet resolve GenericForeignKey async - https://github.com/Arfey/django-async-backend/pull/40#discussion_r3419836145
 - Signal.asend() runs sync receivers through sync_to_async, so pre_delete/post_delete receivers execute on a separate sync connection outside the async transaction
 - Collector.collect() only()s away the parent columns of multi-table inheritance children, so `getattr(obj, ptr.name)` refetches each parent one query at a time — we widen the only() mask instead, which is one query rather than N
+- override_settings() only accepts SimpleTestCase subclasses — we subclass it to widen the check

--- a/django_async_backend/db/backends/base/base.py
+++ b/django_async_backend/db/backends/base/base.py
@@ -57,8 +57,8 @@ class BaseAsyncDatabaseWrapper:
 
     queries_limit = 9000
 
-    # The asyncio task that owns this connection, stamped by
-    # AsyncConnectionHandler.create_connection(). None means unowned.
+    # The asyncio task that owns this connection, claimed on first use by
+    # validate_task_sharing(). None means unowned.
     _task = None
 
     def __init__(self, settings_dict, alias=DEFAULT_DB_ALIAS):
@@ -648,26 +648,26 @@ class BaseAsyncDatabaseWrapper:
     def validate_task_sharing(self):
         """
         Validate that the connection isn't accessed by an asyncio task other
-        than the one which originally created it. Raise an exception if the
+        than the one which first used it. Raise an exception if the
         validation fails.
 
         There is no opt-out: a task that needs its own transaction must get
         its own connection via `async_new_connection()`.
         """
-        # _task is None when the connection was never stamped by
-        # create_connection(), so it isn't bound to any task.
-        if self._task is None:
-            return
-
         try:
             current_task = asyncio.current_task()
         except RuntimeError:
             current_task = None
 
+        if self._task is None:
+            if current_task is not None:
+                self._task = current_task
+            return
+
         if self._task is not current_task:
             raise RuntimeError(
                 "An async connection can only be used by the task that "
-                "created it. The connection with alias '%s' is owned by "
+                "first used it. The connection with alias '%s' is owned by "
                 "another task. Either do this work in the owning task, or "
                 "wrap it in async_new_connection() to give it a separate "
                 "connection." % self.alias

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -77,6 +77,20 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
                 test_settings.setdefault(key, value)
         return databases
 
+    def all(self, initialized_only=False):
+        connections = []
+
+        for alias in self:
+            if initialized_only and not hasattr(self._connections, alias):
+                continue
+
+            try:
+                connections.append(self[alias])
+            except self.exception_class:
+                continue
+
+        return connections
+
     def create_connection(self, alias):
         db = self.settings[alias]
         backend = load_backend(db["ENGINE"])

--- a/django_async_backend/db/utils.py
+++ b/django_async_backend/db/utils.py
@@ -96,9 +96,7 @@ class AsyncConnectionHandler(BaseAsyncConnectionHandler):
                 "Cannot create an async connection without a running "
                 "event loop."
             )
-        wrapper = backend.AsyncDatabaseWrapper(db, alias)
-        wrapper._task = task
-        return wrapper
+        return backend.AsyncDatabaseWrapper(db, alias)
 
 
 async_connections = AsyncConnectionHandler()

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -4,6 +4,8 @@ from unittest import IsolatedAsyncioTestCase
 
 from django.core.signals import request_started
 from django.db import reset_queries
+from django.test.utils import modify_settings as _modify_settings
+from django.test.utils import override_settings as _override_settings
 
 from django_async_backend.db import async_connections
 from django_async_backend.db.transaction import async_atomic
@@ -25,6 +27,19 @@ def _refresh_connection_task_ownership_decorator(fn):
 class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
     databases = "__all__"
 
+    _overridden_settings = None
+    _modified_settings = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if cls._overridden_settings:
+            cls.enterClassContext(
+                _override_settings(**cls._overridden_settings)
+            )
+        if cls._modified_settings:
+            cls.enterClassContext(_modify_settings(cls._modified_settings))
+
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
@@ -43,6 +58,12 @@ class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
                 name,
                 _refresh_connection_task_ownership_decorator(method),
             )
+
+    def settings(self, **kwargs):
+        return override_settings(**kwargs)
+
+    def modify_settings(self, **kwargs):
+        return modify_settings(**kwargs)
 
     def _callSetUp(self):
         self._asyncioRunner.get_loop()
@@ -108,6 +129,29 @@ class AsyncioTestCase(AsyncioTransactionTestCase):
             )
         )
         self._asyncioTestContext.run(self.tearDown)
+
+
+def _save_options_for_supported_class(decorator, cls):
+    from django.test import SimpleTestCase
+
+    if not issubclass(cls, (SimpleTestCase, AsyncioTransactionTestCase)):
+        raise ValueError(
+            "Only subclasses of Django SimpleTestCase or "
+            "AsyncioTransactionTestCase can be decorated with %s"
+            % type(decorator).__name__
+        )
+    decorator.save_options(cls)
+    return cls
+
+
+class override_settings(_override_settings):
+    def decorate_class(self, cls):
+        return _save_options_for_supported_class(self, cls)
+
+
+class modify_settings(_modify_settings):
+    def decorate_class(self, cls):
+        return _save_options_for_supported_class(self, cls)
 
 
 class AsyncCaptureQueriesContext:

--- a/django_async_backend/test.py
+++ b/django_async_backend/test.py
@@ -15,8 +15,7 @@ def _refresh_connection_task_ownership_decorator(fn):
     @wraps(fn)
     async def inner(*args, **kwargs):
         task = asyncio.current_task()
-        for name in async_connections.settings.keys():
-            connection = async_connections[name]
+        for connection in async_connections.all():
             connection._task = task
         return await fn(*args, **kwargs)
 
@@ -73,8 +72,8 @@ class AsyncioTransactionTestCase(IsolatedAsyncioTestCase):
         )
 
     async def _close_connection(self):
-        for name in async_connections.settings.keys():
-            await async_connections[name].close()
+        for connection in async_connections.all():
+            await connection.close()
 
     def _callTearDown(self):
         self._callAsync(
@@ -95,15 +94,14 @@ class AsyncioTestCase(AsyncioTransactionTestCase):
         self.atomic_cms = {}
         self.atomics = {}
 
-        for name in async_connections.settings.keys():
-            connection = async_connections[name]
+        for connection in async_connections.all():
+            name = connection.alias
             self.connections[name] = connection
             self.atomic_cms[name] = async_atomic(name)
             self.atomics[name] = await self.atomic_cms[name].__aenter__()
 
     async def _close_transaction(self):
-        for name in async_connections.settings.keys():
-            connection = async_connections[name]
+        for name, connection in self.connections.items():
             connection.set_rollback(True)
             await self.atomic_cms[name].__aexit__(None, None, None)
             await connection.close()

--- a/docs/source/concurrency.md
+++ b/docs/source/concurrency.md
@@ -18,7 +18,7 @@ await Publisher.async_objects.acount()
 ```
 
 Nor can you fan the work out onto that connection to speed it up. It is owned
-by the task that created it, so handing it to another task — via
+by the task that first used it, so handing it to another task — via
 `asyncio.gather()`, `asyncio.create_task()` or `asyncio.TaskGroup` — raises
 `RuntimeError` rather than quietly interleaving commands on it:
 

--- a/docs/source/testing.md
+++ b/docs/source/testing.md
@@ -44,6 +44,35 @@ class MyTransactionTests(AsyncioTransactionTestCase):
 
 Both test cases close every configured async connection during teardown.
 
+## Overriding settings
+
+Django's `@override_settings` only accepts `SimpleTestCase` subclasses, so it
+raises `ValueError` on the async test cases. Import it from
+`django_async_backend.test` instead — same API, and it also works on Django's
+own test cases, so a module can use the one import for both:
+
+```python
+from django_async_backend.test import AsyncioTestCase, override_settings
+
+
+@override_settings(SOME_SETTING="value")
+class MyAsyncTests(AsyncioTestCase):
+    async def test_something(self):
+        ...
+```
+
+`modify_settings` is available from the same place.
+
+To override a setting for part of a test only, use `self.settings()` or
+`self.modify_settings()` as a context manager:
+
+```python
+class MyAsyncTests(AsyncioTestCase):
+    async def test_something(self):
+        with self.settings(SOME_SETTING="value"):
+            ...
+```
+
 ## Running the test suite
 
 See [Contributing](contribute.md) for running this project's own tests.

--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -45,7 +45,7 @@ async with async_atomic():
 
 ## Transactions and asyncio tasks
 
-An async connection is owned by the task that created it. Using it from a
+An async connection is owned by the task that first used it. Using it from a
 **different** task — one spawned with `asyncio.create_task()`,
 `asyncio.gather()`, or `asyncio.TaskGroup` — is rejected. This applies to *every*
 operation on the connection, not just to opening a transaction: an ordinary

--- a/tests/db/test_asgi_request_signals.py
+++ b/tests/db/test_asgi_request_signals.py
@@ -1,0 +1,70 @@
+import sys
+
+from asgiref.testing import ApplicationCommunicator
+from django.core.asgi import get_asgi_application
+from django.core.signals import got_request_exception
+from django.http import HttpResponse
+from django.test import AsyncRequestFactory
+from django.urls import path
+from test_app.models import TestModel
+
+from django_async_backend.db import async_connections
+from django_async_backend.test import (
+    AsyncioTransactionTestCase,
+    override_settings,
+)
+
+
+async def index(request):
+    await TestModel.async_objects.acount()
+    return HttpResponse("ok")
+
+
+urlpatterns = [path("", index)]
+
+
+@override_settings(ROOT_URLCONF=__name__, ALLOWED_HOSTS=["testserver"])
+class ASGIRequestSignalTaskOwnershipTest(
+    # Not AsyncioTestCase: that wraps each test in an atomic block per alias,
+    # and this test closes and drops those connections so the request opens
+    # its own, which leaves _close_transaction() with no atomic block to exit.
+    AsyncioTransactionTestCase
+):
+    async_request_factory = AsyncRequestFactory()
+
+    async def _drop_test_owned_connections(self):
+        for alias in async_connections.settings:
+            await async_connections[alias].close()
+            del async_connections[alias]
+
+    async def test_request_does_not_trip_task_ownership(self):
+        await self._drop_test_owned_connections()
+
+        captured = []
+
+        def record_exception(sender, **kwargs):
+            captured.append(sys.exc_info()[1])
+
+        got_request_exception.connect(record_exception)
+        self.addCleanup(got_request_exception.disconnect, record_exception)
+
+        scope = self.async_request_factory._base_scope(path="/")
+        communicator = ApplicationCommunicator(get_asgi_application(), scope)
+        await communicator.send_input({"type": "http.request", "body": b""})
+
+        start = await communicator.receive_output(timeout=5)
+        self.assertEqual(start["type"], "http.response.start")
+
+        body = await communicator.receive_output(timeout=5)
+        self.assertEqual(body["type"], "http.response.body")
+
+        self.assertEqual(
+            start["status"],
+            200,
+            "request failed with: %r" % (captured,),
+        )
+        self.assertEqual(body["body"], b"ok")
+
+        # request_finished is emitted after the body; it must not blow up
+        # either.
+        await communicator.wait(timeout=5)

--- a/tests/db/test_asgi_request_signals.py
+++ b/tests/db/test_asgi_request_signals.py
@@ -33,9 +33,9 @@ class ASGIRequestSignalTaskOwnershipTest(
     async_request_factory = AsyncRequestFactory()
 
     async def _drop_test_owned_connections(self):
-        for alias in async_connections.settings:
-            await async_connections[alias].close()
-            del async_connections[alias]
+        for connection in async_connections.all():
+            await connection.close()
+            del async_connections[connection.alias]
 
     async def test_request_does_not_trip_task_ownership(self):
         await self._drop_test_owned_connections()

--- a/tests/db/test_close_old_async_connections.py
+++ b/tests/db/test_close_old_async_connections.py
@@ -31,3 +31,12 @@ class CloseOldAsyncConnectionsTest(SimpleTestCase):
             await close_old_async_connections(
                 sender=object(), signal=object(), environ={}
             )
+
+    async def test_skips_sync_only_alias(self):
+        self.assertIn("legacy", async_connections.settings)
+
+        await close_old_async_connections()
+
+        self.assertNotIn(
+            "legacy", [conn.alias for conn in async_connections.all()]
+        )

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -2,6 +2,27 @@ from django.db import DEFAULT_DB_ALIAS
 from django.test import TestCase
 
 from django_async_backend.db.utils import AsyncConnectionHandler
+from django_async_backend.test import AsyncioTransactionTestCase
+
+
+def mixed_handler():
+    """A handler with an async alias next to a sync-only sqlite one."""
+    return AsyncConnectionHandler(
+        {
+            DEFAULT_DB_ALIAS: {
+                "ENGINE": "django_async_backend.db.backends.postgresql",
+                "NAME": "postgres",
+                "USER": "postgres",
+                "PASSWORD": "postgres",
+                "HOST": "localhost",
+                "PORT": 5432,
+            },
+            "legacy": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            },
+        }
+    )
 
 
 class AsyncConnectionHandlerSyncTests(TestCase):
@@ -12,4 +33,36 @@ class AsyncConnectionHandlerSyncTests(TestCase):
         self.assertEqual(
             str(cm.exception),
             "Cannot create an async connection without a running event loop.",
+        )
+
+
+class AsyncConnectionHandlerAllTests(AsyncioTransactionTestCase):
+
+    async def test_all_skips_sync_only_aliases(self):
+        handler = mixed_handler()
+
+        self.assertEqual(
+            [conn.alias for conn in handler.all()], [DEFAULT_DB_ALIAS]
+        )
+
+    async def test_getitem_still_raises_for_sync_only_alias(self):
+        handler = mixed_handler()
+
+        with self.assertRaises(handler.exception_class) as cm:
+            handler["legacy"]
+
+        self.assertEqual(
+            str(cm.exception), "The async connection 'legacy' doesn't exist."
+        )
+
+    async def test_all_initialized_only_skips_untouched_aliases(self):
+        handler = mixed_handler()
+
+        self.assertEqual(handler.all(initialized_only=True), [])
+
+        handler[DEFAULT_DB_ALIAS]
+
+        self.assertEqual(
+            [conn.alias for conn in handler.all(initialized_only=True)],
+            [DEFAULT_DB_ALIAS],
         )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -14,7 +14,11 @@ DATABASES = {
         "PASSWORD": "postgres",
         "HOST": "localhost",
         "PORT": 5432,
-    }
+    },
+    "legacy": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
 }
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Most-played tracks:

- [Twin Rova & KVDE - Tidal Waves](https://music.youtube.com/watch?v=Z8qEjmlJ8jM)
- [Jutes - Kill or be Killed (MAPHRA Vocal Cover)](https://www.youtube.com/watch?v=sZALWV6Af_A)

## Summary by Sourcery

Ensure async connections are owned by the task that first uses them and release only connections managed by the async backend.

New Features:
- Add async test helpers for overriding and modifying settings on async test cases.
- Add connection-handler enumeration that safely skips sync-only and optionally uninitialized aliases.

Bug Fixes:
- Bind async database connections to the task that first uses them, allowing connections created by ASGI request handling to be cleaned up without ownership errors.
- Ensure connection cleanup and transaction management operate only on available async connections.

Enhancements:
- Update async test infrastructure to discover and manage connections dynamically rather than assuming every configured database has an async backend.

Documentation:
- Document async-compatible settings override and modification helpers for test classes and test scopes.

Tests:
- Add coverage for task ownership during ASGI requests, mixed sync and async database configurations, and skipping sync-only connections during cleanup.

Chores:
- Note the remaining limitation around Django's override_settings support for async test cases.

## Summary by Sourcery

Ensure async connections are owned and released by the task that uses them while making test infrastructure safe for mixed database configurations.

New Features:
- Add async-compatible settings override and modification helpers for test classes and test scopes.
- Provide connection enumeration that safely excludes sync-only and optionally uninitialized aliases.

Bug Fixes:
- Bind async connections to the task that first uses them and restrict cleanup and transaction handling to available async connections.

Enhancements:
- Update async test connection management to discover configured async connections dynamically.

Documentation:
- Update concurrency documentation to describe first-use task ownership and document async settings helpers.

Tests:
- Add coverage for ASGI request task ownership, mixed sync and async database configurations, and skipping sync-only connections during cleanup.

Chores:
- Document the remaining limitation of Django's built-in override_settings support for async test cases.