### PR TITLE
feat: support prefetch_related() on async querysets

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Legend: ✅ supported · ❌ not supported · ⚠️ supported with caveats
 | `Model.objects.difference`          | ✅        |          |
 | `Model.objects.select_related`      | ❌        |          |
 | `Model.objects.select_for_update`   | ✅        |          |
-| `Model.objects.prefetch_related`    | ❌        |          |
+| `Model.objects.prefetch_related`    | ⚠️        | `GenericForeignKey` and `GenericRelation` are not supported |
 | `Model.objects.aaggregate`          | ❌        |          |
 | `Model.objects.annotate`            | ✅        |          |
 | `Model.objects.order_by`            | ✅        |          |

--- a/codemon/config/db__models__query.yaml
+++ b/codemon/config/db__models__query.yaml
@@ -6,6 +6,7 @@ module:
     - "from django_async_backend.db.models import sql as async_sql"
     - "from django_async_backend.db.transaction import async_atomic"
     - "from django_async_backend.db.transaction import async_mark_for_rollback_on_error"
+    - "from django_async_backend.db.models.prefetch import prefetch_one_level"
 
   import_aliases:
     # The async Collector lives in django_async_backend.db.models.deletion,
@@ -16,12 +17,44 @@ module:
   functions:
     prefetch_related_objects:
       to_async: true
+      calls:
+        - func:
+            name: prefetch_one_level
+          to_await: true
 
-    # todo:
-    # aprefetch_related_objects:
-    #   remove: true
+    # The async prefetch_one_level() lives in
+    # django_async_backend.db.models.prefetch, because it has to build and
+    # evaluate the related querysets asynchronously.
+    prefetch_one_level:
+      remove: true
+
+    # Replaced by an alias of the async prefetch_related_objects() below.
+    aprefetch_related_objects:
+      remove: true
+
+  add_raw_bottom:
+    - |
+      aprefetch_related_objects = prefetch_related_objects
 
   classes:
+    Prefetch:
+      methods:
+        __init__:
+          add_raw_top:
+            - |
+              if not isinstance(lookup, str):
+                  raise TypeError(
+                      "Prefetch lookups must be strings. Use "
+                      "django_async_backend.db.models.query.Prefetch instead of "
+                      "django.db.models.Prefetch."
+                  )
+            - |
+              if queryset is not None and not isinstance(queryset, QuerySet):
+                  raise ValueError(
+                      "Prefetch querysets must be async querysets. "
+                      "Use Model.async_objects instead of Model.objects."
+                  )
+
     QuerySet:
       add_raw_top:
         - |
@@ -104,6 +137,18 @@ module:
           remove: true
 
       methods:
+        prefetch_related:
+          add_raw_top:
+            - |
+              if any(
+                  lookup is not None and not isinstance(lookup, (str, Prefetch))
+                  for lookup in lookups
+              ):
+                  raise TypeError(
+                      "prefetch_related() lookups must be strings or "
+                      "django_async_backend.db.models.query.Prefetch instances."
+                  )
+
         __init__:
           calls:
             - func:
@@ -206,9 +251,6 @@ module:
           remove: true
 
         raw:
-          remove: true
-
-        prefetch_related:
           remove: true
 
         ain_bulk:

--- a/django_async_backend/db/models/prefetch.py
+++ b/django_async_backend/db/models/prefetch.py
@@ -1,0 +1,349 @@
+"""Async counterpart of ``django.db.models.query.prefetch_one_level()``.
+
+Django resolves a prefetch by asking the descriptor (or the related manager)
+for ``get_prefetch_querysets()``. Every implementation of that hook builds a
+*sync* queryset and, for single-valued relations, iterates it right away to
+populate the reverse relation cache. Both halves are unusable here: the
+queryset has to be an async one, and it can only be consumed with ``async
+for``.
+
+So the descriptor code is mirrored below instead of being called. Each branch
+returns the same six-tuple Django's hook returns -- unevaluated -- plus a
+callback that performs the cache bookkeeping the sync code did while
+iterating. ``prefetch_one_level()`` then evaluates the queryset with ``async
+for`` and runs that callback.
+
+Relations whose prefetch cannot be expressed this way (generic foreign keys,
+generic relations, custom descriptors) raise ``NotSupportedError``.
+"""
+
+import copy
+
+from django.core import exceptions
+from django.db import NotSupportedError
+from django.db.models.expressions import ColPairs
+from django.db.models.fields.related_descriptors import (
+    ForwardManyToOneDescriptor,
+    ReverseOneToOneDescriptor,
+    _filter_prefetch_queryset,
+)
+from django.db.models.fields.tuple_lookups import TupleIn
+
+RELATED_DESCRIPTORS_MODULE = "django.db.models.fields.related_descriptors"
+
+
+def _async_queryset(model, using=None, hints=None):
+    """Async equivalent of ``Manager.get_queryset()`` on a plain manager."""
+    # Imported lazily: django_async_backend.db.models.query imports this
+    # module at import time.
+    from django_async_backend.db.models.query import QuerySet
+
+    return QuerySet(model=model, using=using, hints=hints)
+
+
+def _descriptor_queryset(model, instance):
+    """Async equivalent of the descriptors' ``get_queryset(instance=...)``:
+    ``model._base_manager.db_manager(hints={"instance": instance}).fetch_mode(
+    instance._state.fetch_mode)``.
+    """
+    queryset = _async_queryset(model, hints={"instance": instance})
+    return queryset.fetch_mode(instance._state.fetch_mode)
+
+
+def _unsupported(prefetcher):
+    name = getattr(prefetcher, "name", None)
+    if name is None:
+        # Descriptors (e.g. GenericForeignKeyDescriptor) wrap the field.
+        name = getattr(getattr(prefetcher, "field", None), "name", None)
+    if name is None:
+        name = type(prefetcher).__name__
+    raise NotSupportedError(
+        "prefetch_related() for %s is not supported by the async backend."
+        % name
+    )
+
+
+def _single_queryset(querysets):
+    if querysets and len(querysets) != 1:
+        raise ValueError(
+            "querysets argument of get_prefetch_querysets() should have a "
+            "length of 1."
+        )
+    return querysets[0] if querysets else None
+
+
+def _noop(related_objects):
+    pass
+
+
+def _forward_many_to_one(descriptor, instances, querysets):
+    """Mirror of ``ForwardManyToOneDescriptor.get_prefetch_querysets()``."""
+    field = descriptor.field
+    queryset = _single_queryset(querysets)
+    cloning_disabled = queryset is None
+    if cloning_disabled:
+        queryset = _descriptor_queryset(
+            field.remote_field.model, instances[0]
+        )._disable_cloning()
+
+    rel_obj_attr = field.get_foreign_related_value
+    instance_attr = field.get_local_related_value
+    instances_dict = {instance_attr(inst): inst for inst in instances}
+    remote_field = field.remote_field
+    related_fields = [
+        queryset.query.resolve_ref(related_field.name).target
+        for related_field in field.foreign_related_fields
+    ]
+    queryset = queryset.filter(
+        TupleIn(
+            ColPairs(
+                queryset.model._meta.db_table,
+                related_fields,
+                related_fields,
+                field,
+            ),
+            list(instances_dict),
+        )
+    )
+    # There can be only one object prefetched for each instance so clear
+    # ordering if the query allows it without side effects.
+    queryset.query.clear_ordering()
+    # Restore subsequent cloning operations.
+    if cloning_disabled:
+        queryset._enable_cloning()
+
+    def post_evaluate(related_objects):
+        # Since we're going to assign directly in the cache,
+        # we must manage the reverse relation cache manually.
+        if not remote_field.multiple:
+            for rel_obj in related_objects:
+                instance = instances_dict[rel_obj_attr(rel_obj)]
+                remote_field.set_cached_value(rel_obj, instance)
+
+    return (
+        queryset,
+        rel_obj_attr,
+        instance_attr,
+        True,
+        field.cache_name,
+        False,
+        post_evaluate,
+    )
+
+
+def _reverse_one_to_one(descriptor, instances, querysets):
+    """Mirror of ``ReverseOneToOneDescriptor.get_prefetch_querysets()``."""
+    related = descriptor.related
+    queryset = _single_queryset(querysets)
+    cloning_disabled = queryset is None
+    if cloning_disabled:
+        queryset = _descriptor_queryset(
+            related.related_model, instances[0]
+        )._disable_cloning()
+
+    rel_obj_attr = related.field.get_local_related_value
+    instance_attr = related.field.get_foreign_related_value
+    instances_dict = {instance_attr(inst): inst for inst in instances}
+    query = {"%s__in" % related.field.name: instances}
+    queryset = queryset.filter(**query)
+    queryset.query.clear_ordering()
+    # Restore subsequent cloning operations.
+    if cloning_disabled:
+        queryset._enable_cloning()
+
+    def post_evaluate(related_objects):
+        for rel_obj in related_objects:
+            instance = instances_dict[rel_obj_attr(rel_obj)]
+            related.field.set_cached_value(rel_obj, instance)
+
+    return (
+        queryset,
+        rel_obj_attr,
+        instance_attr,
+        True,
+        related.cache_name,
+        False,
+        post_evaluate,
+    )
+
+
+def _reverse_many_to_one(manager, instances, querysets):
+    """Mirror of the reverse FK ``RelatedManager.get_prefetch_querysets()``."""
+    field = manager.field
+    queryset = _single_queryset(querysets)
+    cloning_disabled = queryset is None
+    if cloning_disabled:
+        queryset = _async_queryset(
+            manager.model, using=manager._db, hints=manager._hints
+        )._disable_cloning()
+
+    queryset._add_hints(instance=instances[0])
+    queryset = queryset.using(queryset._db or manager._db)
+
+    rel_obj_attr = field.get_local_related_value
+    instance_attr = field.get_foreign_related_value
+    instances_dict = {instance_attr(inst): inst for inst in instances}
+    queryset = _filter_prefetch_queryset(queryset, field.name, instances)
+    # Restore subsequent cloning operations.
+    if cloning_disabled:
+        queryset._enable_cloning()
+
+    def post_evaluate(related_objects):
+        # Since we just bypassed the manager's get_queryset(), we must manage
+        # the reverse relation manually.
+        for rel_obj in related_objects:
+            if not field.is_cached(rel_obj):
+                instance = instances_dict[rel_obj_attr(rel_obj)]
+                field.set_cached_value(rel_obj, instance)
+
+    return (
+        queryset,
+        rel_obj_attr,
+        instance_attr,
+        False,
+        field.remote_field.cache_name,
+        False,
+        post_evaluate,
+    )
+
+
+def _many_to_many(manager, instances, querysets):
+    """Delegate to ``ManyRelatedManager.get_prefetch_querysets()``.
+
+    That implementation only annotates the queryset with the join table
+    columns; it never evaluates it. Handing it an async queryset is therefore
+    enough to make it async.
+    """
+    queryset = _single_queryset(querysets)
+    if queryset is None:
+        queryset = _async_queryset(
+            manager.model, using=manager._db, hints=manager._hints
+        )
+
+    return (*manager.get_prefetch_querysets(instances, [queryset]), _noop)
+
+
+def _get_prefetch_querysets(prefetcher, instances, querysets):
+    """Build the related queryset for ``prefetcher`` without evaluating it.
+
+    Return Django's ``get_prefetch_querysets()`` six-tuple plus a
+    ``post_evaluate(related_objects)`` callback.
+    """
+    if isinstance(prefetcher, ForwardManyToOneDescriptor):
+        # Also covers ForwardOneToOneDescriptor.
+        return _forward_many_to_one(prefetcher, instances, querysets)
+
+    if isinstance(prefetcher, ReverseOneToOneDescriptor):
+        return _reverse_one_to_one(prefetcher, instances, querysets)
+
+    # Related managers are built by factories in related_descriptors, so the
+    # generated classes are the only reliable marker. Generic relation
+    # managers come from django.contrib.contenttypes.fields instead, and are
+    # rejected below together with GenericForeignKey.
+    if type(prefetcher).__module__ == RELATED_DESCRIPTORS_MODULE:
+        if hasattr(prefetcher, "through"):
+            return _many_to_many(prefetcher, instances, querysets)
+        return _reverse_many_to_one(prefetcher, instances, querysets)
+
+    return _unsupported(prefetcher)
+
+
+async def prefetch_one_level(instances, prefetcher, lookup, level):
+    """
+    Helper function for prefetch_related_objects().
+
+    Run prefetches on all instances using the prefetcher object,
+    assigning results to relevant caches in instance.
+
+    Return the prefetched objects along with any additional prefetches that
+    must be done due to prefetch_related lookups found from default managers.
+    """
+    (
+        rel_qs,
+        rel_obj_attr,
+        instance_attr,
+        single,
+        cache_name,
+        is_descriptor,
+        post_evaluate,
+    ) = _get_prefetch_querysets(
+        prefetcher, instances, lookup.get_current_querysets(level)
+    )
+    # We have to handle the possibility that the QuerySet we just got back
+    # contains some prefetch_related lookups. We don't want to trigger the
+    # prefetch_related functionality by evaluating the query. Rather, we need
+    # to merge in the prefetch_related lookups.
+    # Copy the lookups in case it is a Prefetch object which could be reused
+    # later (happens in nested prefetch_related).
+    additional_lookups = [
+        copy.copy(additional_lookup)
+        for additional_lookup in getattr(
+            rel_qs, "_prefetch_related_lookups", ()
+        )
+    ]
+    if additional_lookups:
+        # Don't need to clone because the manager should have given us a fresh
+        # instance, so we access an internal instead of using public interface
+        # for performance reasons.
+        rel_qs._prefetch_related_lookups = ()
+
+    all_related_objects = [rel_obj async for rel_obj in rel_qs]
+    # The sync descriptors fill the reverse relation caches while iterating;
+    # do it now that the queryset has been consumed.
+    post_evaluate(all_related_objects)
+
+    rel_obj_cache = {}
+    for rel_obj in all_related_objects:
+        rel_attr_val = rel_obj_attr(rel_obj)
+        rel_obj_cache.setdefault(rel_attr_val, []).append(rel_obj)
+
+    to_attr, as_attr = lookup.get_current_to_attr(level)
+    # Make sure `to_attr` does not conflict with a field.
+    if as_attr and instances:
+        # We assume that objects retrieved are homogeneous (which is the
+        # premise of prefetch_related), so what applies to first object applies
+        # to all.
+        model = instances[0].__class__
+        try:
+            model._meta.get_field(to_attr)
+        except exceptions.FieldDoesNotExist:
+            pass
+        else:
+            raise ValueError(
+                "to_attr=%s conflicts with a field on the %s model."
+                % (to_attr, model.__name__)
+            )
+
+    for obj in instances:
+        instance_attr_val = instance_attr(obj)
+        vals = rel_obj_cache.get(instance_attr_val, [])
+
+        if single:
+            val = vals[0] if vals else None
+            if as_attr:
+                # A to_attr has been given for the prefetch.
+                setattr(obj, to_attr, val)
+            elif is_descriptor:
+                # cache_name points to a field name in obj.
+                # This field is a descriptor for a related object.
+                setattr(obj, cache_name, val)
+            else:
+                # No to_attr has been given for this prefetch operation and the
+                # cache_name does not point to a descriptor. Store the value of
+                # the field in the object's field cache.
+                obj._state.fields_cache[cache_name] = val
+        else:
+            if as_attr:
+                setattr(obj, to_attr, vals)
+            else:
+                manager = getattr(obj, to_attr)
+                # Related managers expose Django's synchronous queryset API.
+                # Keep the cache shape consistent even when an async custom
+                # queryset supplied the prefetched values.
+                qs = manager.get_queryset()
+                qs._result_cache = vals
+                # We don't want the individual qs doing prefetch_related now,
+                # since we have merged this into the current work.
+                qs._prefetch_done = True
+                obj._prefetched_objects_cache[cache_name] = qs
+    return all_related_objects, additional_lookups

--- a/django_async_backend/db/models/query.py
+++ b/django_async_backend/db/models/query.py
@@ -1,6 +1,7 @@
 # This file was generated automatically. Do not modify it manually. (based on django 6.1)
 from django_async_backend.db import async_connections
 from django_async_backend.db.models import sql as async_sql
+from django_async_backend.db.models.prefetch import prefetch_one_level
 from django_async_backend.db.transaction import (
     async_atomic,
     async_mark_for_rollback_on_error,
@@ -1591,6 +1592,35 @@ class QuerySet(AltersData):
             obj.query.select_related = True
         return obj
 
+    def prefetch_related(self, *lookups):
+
+        if any(
+            lookup is not None and not isinstance(lookup, (str, Prefetch))
+            for lookup in lookups
+        ):
+            raise TypeError(
+                "prefetch_related() lookups must be strings or "
+                "django_async_backend.db.models.query.Prefetch instances."
+            )
+
+        self._not_support_combined_queries("prefetch_related")
+        clone = self._chain()
+        if lookups == (None,):
+            clone._prefetch_related_lookups = ()
+        else:
+            for lookup in lookups:
+                if isinstance(lookup, Prefetch):
+                    lookup = lookup.prefetch_to
+                lookup = lookup.split(LOOKUP_SEP, 1)[0]
+                if lookup in self.query._filtered_relations:
+                    raise ValueError(
+                        "prefetch_related() is not supported with FilteredRelation."
+                    )
+            clone._prefetch_related_lookups = (
+                clone._prefetch_related_lookups + lookups
+            )
+        return clone
+
     def annotate(self, *args, **kwargs):
         self._not_support_combined_queries("annotate")
         return self._annotate(args, kwargs, select=True)
@@ -2215,6 +2245,20 @@ class RawQuerySet:
 
 class Prefetch:
     def __init__(self, lookup, queryset=None, to_attr=None):
+
+        if not isinstance(lookup, str):
+            raise TypeError(
+                "Prefetch lookups must be strings. Use "
+                "django_async_backend.db.models.query.Prefetch instead of "
+                "django.db.models.Prefetch."
+            )
+
+        if queryset is not None and not isinstance(queryset, QuerySet):
+            raise ValueError(
+                "Prefetch querysets must be async querysets. "
+                "Use Model.async_objects instead of Model.objects."
+            )
+
         # `prefetch_through` is the path we traverse to perform the prefetch.
         self.prefetch_through = lookup
         # `prefetch_to` is the path to the attribute that stores the result.
@@ -2387,7 +2431,7 @@ async def prefetch_related_objects(model_instances, *related_lookups):
                 obj_to_fetch = [obj for obj in obj_list if not is_fetched(obj)]
 
             if obj_to_fetch:
-                obj_list, additional_lookups = prefetch_one_level(
+                obj_list, additional_lookups = await prefetch_one_level(
                     obj_to_fetch,
                     prefetcher,
                     lookup,
@@ -2442,12 +2486,6 @@ async def prefetch_related_objects(model_instances, *related_lookups):
                     else:
                         new_obj_list.append(new_obj)
                 obj_list = new_obj_list
-
-
-async def aprefetch_related_objects(model_instances, *related_lookups):
-    return await sync_to_async(prefetch_related_objects)(
-        model_instances, *related_lookups
-    )
 
 
 def get_prefetcher(instance, through_attr, to_attr):
@@ -2505,109 +2543,6 @@ def get_prefetcher(instance, through_attr, to_attr):
 
                     is_fetched = in_prefetched_cache
     return prefetcher, rel_obj_descriptor, attr_found, is_fetched
-
-
-def prefetch_one_level(instances, prefetcher, lookup, level):
-    # prefetcher must have a method get_prefetch_querysets() which takes a list
-    # of instances, and returns a tuple:
-
-    # (queryset of instances of self.model that are related to passed in
-    #  instances,
-    #  callable that gets value to be matched for returned instances,
-    #  callable that gets value to be matched for passed in instances,
-    #  boolean that is True for singly related objects,
-    #  cache or field name to assign to,
-    #  boolean that is True when the previous argument is a cache name vs a
-    #  field name).
-
-    # The 'values to be matched' must be hashable as they will be used
-    # in a dictionary.
-    (
-        rel_qs,
-        rel_obj_attr,
-        instance_attr,
-        single,
-        cache_name,
-        is_descriptor,
-    ) = prefetcher.get_prefetch_querysets(
-        instances, lookup.get_current_querysets(level)
-    )
-    # We have to handle the possibility that the QuerySet we just got back
-    # contains some prefetch_related lookups. We don't want to trigger the
-    # prefetch_related functionality by evaluating the query. Rather, we need
-    # to merge in the prefetch_related lookups.
-    # Copy the lookups in case it is a Prefetch object which could be reused
-    # later (happens in nested prefetch_related).
-    additional_lookups = [
-        copy.copy(additional_lookup)
-        for additional_lookup in getattr(
-            rel_qs, "_prefetch_related_lookups", ()
-        )
-    ]
-    if additional_lookups:
-        # Don't need to clone because the manager should have given us a fresh
-        # instance, so we access an internal instead of using public interface
-        # for performance reasons.
-        rel_qs._prefetch_related_lookups = ()
-
-    all_related_objects = list(rel_qs)
-
-    rel_obj_cache = {}
-    for rel_obj in all_related_objects:
-        rel_attr_val = rel_obj_attr(rel_obj)
-        rel_obj_cache.setdefault(rel_attr_val, []).append(rel_obj)
-
-    to_attr, as_attr = lookup.get_current_to_attr(level)
-    # Make sure `to_attr` does not conflict with a field.
-    if as_attr and instances:
-        # We assume that objects retrieved are homogeneous (which is the
-        # premise of prefetch_related), so what applies to first object applies
-        # to all.
-        model = instances[0].__class__
-        try:
-            model._meta.get_field(to_attr)
-        except exceptions.FieldDoesNotExist:
-            pass
-        else:
-            msg = "to_attr={} conflicts with a field on the {} model."
-            raise ValueError(msg.format(to_attr, model.__name__))
-
-    # Whether or not we're prefetching the last part of the lookup.
-    leaf = len(lookup.prefetch_through.split(LOOKUP_SEP)) - 1 == level
-
-    for obj in instances:
-        instance_attr_val = instance_attr(obj)
-        vals = rel_obj_cache.get(instance_attr_val, [])
-
-        if single:
-            val = vals[0] if vals else None
-            if as_attr:
-                # A to_attr has been given for the prefetch.
-                setattr(obj, to_attr, val)
-            elif is_descriptor:
-                # cache_name points to a field name in obj.
-                # This field is a descriptor for a related object.
-                setattr(obj, cache_name, val)
-            else:
-                # No to_attr has been given for this prefetch operation and the
-                # cache_name does not point to a descriptor. Store the value of
-                # the field in the object's field cache.
-                obj._state.fields_cache[cache_name] = val
-        else:
-            if as_attr:
-                setattr(obj, to_attr, vals)
-            else:
-                manager = getattr(obj, to_attr)
-                if leaf and lookup.queryset is not None:
-                    qs = manager._apply_rel_filters(lookup.queryset._chain())
-                else:
-                    qs = manager.get_queryset()
-                qs._result_cache = vals
-                # We don't want the individual qs doing prefetch_related now,
-                # since we have merged this into the current work.
-                qs._prefetch_done = True
-                obj._prefetched_objects_cache[cache_name] = qs
-    return all_related_objects, additional_lookups
 
 
 class RelatedPopulator:
@@ -2706,3 +2641,6 @@ def get_related_populators(klass_info, select, db, fetch_mode):
         rel_cls = RelatedPopulator(rel_klass_info, select, db, fetch_mode)
         iterators.append(rel_cls)
     return iterators
+
+
+aprefetch_related_objects = prefetch_related_objects

--- a/docs/source/orm.md
+++ b/docs/source/orm.md
@@ -183,7 +183,7 @@ Legend: ✅ supported · ❌ not supported · ⚠️ supported with caveats
 | `Model.objects.difference`          | ✅        |          |
 | `Model.objects.select_related`      | ❌        |          |
 | `Model.objects.select_for_update`   | ✅        |          |
-| `Model.objects.prefetch_related`    | ❌        |          |
+| `Model.objects.prefetch_related`    | ⚠️        | `GenericForeignKey` and `GenericRelation` are not supported |
 | `Model.objects.aaggregate`          | ❌        |          |
 | `Model.objects.annotate`            | ✅        |          |
 | `Model.objects.order_by`            | ✅        |          |

--- a/tests/db/models/query/test_prefetch_related.py
+++ b/tests/db/models/query/test_prefetch_related.py
@@ -1,0 +1,1039 @@
+import gc
+import warnings
+from collections import deque
+from unittest import mock
+
+from django.core.exceptions import SynchronousOnlyOperation
+from django.db import (
+    DEFAULT_DB_ALIAS,
+    NotSupportedError,
+)
+from django.db.models import Prefetch as DjangoPrefetch
+from django.db.models.fetch_modes import (
+    FETCH_PEERS,
+    FETCH_RAISE,
+)
+from test_app.models import (
+    ChildModel,
+    GenericFkModel,
+    GenericRelationModel,
+    M2MOwnerModel,
+    M2MTagModel,
+    ParentModel,
+    SelectRelatedAuthorModel,
+    SelectRelatedBookModel,
+    SelectRelatedProfileModel,
+    SelectRelatedPublisherModel,
+)
+
+from django_async_backend.db import async_connections
+from django_async_backend.db.models.query import (
+    Prefetch,
+    aprefetch_related_objects,
+)
+from django_async_backend.test import (
+    AsyncCaptureQueriesContext,
+    AsyncioTestCase,
+)
+
+
+class PrefetchRelatedTestCase(AsyncioTestCase):
+    """Shared fixture.
+
+    ``Author1`` owns both books and a profile, ``Author2`` owns neither, so
+    the empty side of every relation is covered as well. ``Book2`` has no
+    publisher, which is the NULL forward foreign key.
+    """
+
+    async def asyncSetUp(self):
+        self.author1 = await SelectRelatedAuthorModel.async_objects.acreate(
+            name="Author1"
+        )
+        self.author2 = await SelectRelatedAuthorModel.async_objects.acreate(
+            name="Author2"
+        )
+        self.profile1 = await SelectRelatedProfileModel.async_objects.acreate(
+            author=self.author1, bio="Bio1"
+        )
+        self.publisher1 = (
+            await SelectRelatedPublisherModel.async_objects.acreate(
+                name="Publisher1"
+            )
+        )
+        self.book1 = await SelectRelatedBookModel.async_objects.acreate(
+            title="Book1", author=self.author1, publisher=self.publisher1
+        )
+        self.book2 = await SelectRelatedBookModel.async_objects.acreate(
+            title="Book2", author=self.author1, publisher=None
+        )
+
+    def capture(self, alias=DEFAULT_DB_ALIAS):
+        return AsyncCaptureQueriesContext(async_connections[alias])
+
+    async def evaluate(self, queryset):
+        return [obj async for obj in queryset]
+
+    async def books(self, queryset):
+        return await self.evaluate(queryset.order_by("title"))
+
+    async def authors(self, queryset):
+        return await self.evaluate(queryset.order_by("name"))
+
+
+class TestPrefetchRelatedQueryConstruction(PrefetchRelatedTestCase):
+    """prefetch_related() only records lookups; nothing here touches the DB."""
+
+    async def test_returns_clone_without_touching_source(self):
+        source = SelectRelatedBookModel.async_objects.all()
+
+        clone = source.prefetch_related("author")
+
+        self.assertIsNot(clone, source)
+        self.assertEqual(source._prefetch_related_lookups, ())
+        self.assertEqual(clone._prefetch_related_lookups, ("author",))
+
+    async def test_chaining_accumulates_lookups(self):
+        queryset = SelectRelatedBookModel.async_objects.prefetch_related(
+            "author"
+        ).prefetch_related("publisher")
+
+        self.assertEqual(
+            queryset._prefetch_related_lookups, ("author", "publisher")
+        )
+
+    async def test_none_clears_lookups(self):
+        queryset = SelectRelatedBookModel.async_objects.prefetch_related(
+            "author"
+        ).prefetch_related(None)
+
+        self.assertEqual(queryset._prefetch_related_lookups, ())
+
+    async def test_lookups_survive_cloning(self):
+        queryset = SelectRelatedBookModel.async_objects.prefetch_related(
+            "author"
+        ).filter(title="Book1")
+
+        self.assertEqual(queryset._prefetch_related_lookups, ("author",))
+
+    async def test_combined_queries_are_rejected(self):
+        combined = SelectRelatedBookModel.async_objects.filter(
+            title="Book1"
+        ).union(SelectRelatedBookModel.async_objects.filter(title="Book2"))
+
+        with self.assertRaises(NotSupportedError):
+            combined.prefetch_related("author")
+
+    async def test_prefetch_rejects_sync_queryset(self):
+        with self.assertRaises(ValueError):
+            Prefetch("books", queryset=SelectRelatedBookModel.objects.all())
+
+    async def test_rejects_django_prefetch_with_clear_error(self):
+        msg = (
+            "prefetch_related() lookups must be strings or "
+            "django_async_backend.db.models.query.Prefetch instances."
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            SelectRelatedAuthorModel.async_objects.prefetch_related(
+                DjangoPrefetch("books")
+            )
+        self.assertEqual(str(ctx.exception), msg)
+
+    async def test_prefetch_equality_and_hash_use_destination(self):
+        prefetch = Prefetch(
+            "books",
+            queryset=SelectRelatedBookModel.async_objects.all(),
+        )
+        same_destination = Prefetch("books")
+        different_destination = Prefetch("books", to_attr="library")
+
+        self.assertEqual(prefetch, prefetch)
+        self.assertEqual(prefetch, mock.ANY)
+        self.assertEqual(prefetch, same_destination)
+        self.assertEqual(hash(prefetch), hash(same_destination))
+        self.assertNotEqual(prefetch, different_destination)
+
+    async def test_prefetch_rejects_non_model_iterables(self):
+        msg = (
+            "Prefetch querysets cannot use raw(), values(), and values_list()."
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            Prefetch(
+                "books",
+                queryset=SelectRelatedBookModel.async_objects.values("pk"),
+            )
+        self.assertEqual(str(ctx.exception), msg)
+        with self.assertRaises(ValueError) as ctx:
+            Prefetch(
+                "books",
+                queryset=SelectRelatedBookModel.async_objects.values_list(
+                    "pk"
+                ),
+            )
+        self.assertEqual(str(ctx.exception), msg)
+
+
+class TestPrefetchRelatedForwardRelations(PrefetchRelatedTestCase):
+
+    async def test_forward_fk_uses_two_queries(self):
+        async with self.capture() as ctx:
+            books = await self.books(
+                SelectRelatedBookModel.async_objects.prefetch_related("author")
+            )
+            names = [book.author.name for book in books]
+
+        self.assertEqual(names, ["Author1", "Author1"])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_forward_fk_is_cached(self):
+        books = await self.books(
+            SelectRelatedBookModel.async_objects.prefetch_related("author")
+        )
+        field = SelectRelatedBookModel._meta.get_field("author")
+
+        async with self.capture() as ctx:
+            for book in books:
+                self.assertTrue(field.is_cached(book))
+                book.author.name
+
+        self.assertEqual(len(ctx.captured_queries), 0)
+
+    async def test_null_forward_fk_yields_none(self):
+        async with self.capture() as ctx:
+            books = await self.books(
+                SelectRelatedBookModel.async_objects.prefetch_related(
+                    "publisher"
+                )
+            )
+            publishers = [book.publisher for book in books]
+
+        self.assertEqual(publishers[0].name, "Publisher1")
+        self.assertIsNone(publishers[1])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_forward_one_to_one(self):
+        async with self.capture() as ctx:
+            profiles = await self.evaluate(
+                SelectRelatedProfileModel.async_objects.prefetch_related(
+                    "author"
+                )
+            )
+            names = [profile.author.name for profile in profiles]
+
+        self.assertEqual(names, ["Author1"])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_forward_relation_copies_fetch_mode(self):
+        books = await self.books(
+            SelectRelatedBookModel.async_objects.fetch_mode(
+                FETCH_PEERS
+            ).prefetch_related("author")
+        )
+
+        self.assertEqual(books[0]._state.fetch_mode, FETCH_PEERS)
+        self.assertEqual(books[0].author._state.fetch_mode, FETCH_PEERS)
+
+    async def test_forward_relation_is_available_in_fetch_raise_mode(self):
+        books = await self.books(
+            SelectRelatedBookModel.async_objects.fetch_mode(
+                FETCH_RAISE
+            ).prefetch_related("author")
+        )
+
+        self.assertEqual(books[0].author.name, "Author1")
+
+    async def test_forward_custom_queryset_can_filter_out_relation(self):
+        books = await self.books(
+            SelectRelatedBookModel.async_objects.filter(
+                title="Book1"
+            ).prefetch_related(
+                Prefetch(
+                    "author",
+                    queryset=SelectRelatedAuthorModel.async_objects.none(),
+                    to_attr="prefetched_author",
+                )
+            )
+        )
+
+        self.assertIsNone(books[0].prefetched_author)
+
+    async def test_forward_prefetch_clears_custom_ordering(self):
+        authors = SelectRelatedAuthorModel.async_objects.order_by("-name")
+
+        async with self.capture() as ctx:
+            await self.books(
+                SelectRelatedBookModel.async_objects.prefetch_related(
+                    Prefetch("author", queryset=authors)
+                )
+            )
+
+        self.assertNotIn("ORDER BY", ctx.captured_queries[1]["sql"])
+
+
+class TestPrefetchRelatedReverseRelations(PrefetchRelatedTestCase):
+
+    async def test_reverse_fk_uses_two_queries(self):
+        async with self.capture() as ctx:
+            authors = await self.authors(
+                SelectRelatedAuthorModel.async_objects.prefetch_related(
+                    "books"
+                )
+            )
+            titles = [
+                sorted(book.title for book in author.books.all())
+                for author in authors
+            ]
+
+        self.assertEqual(titles, [["Book1", "Book2"], []])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_reverse_fk_caches_the_back_reference(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.prefetch_related("books")
+        )
+        field = SelectRelatedBookModel._meta.get_field("author")
+
+        async with self.capture() as ctx:
+            for book in authors[0].books.all():
+                self.assertTrue(field.is_cached(book))
+                self.assertEqual(book.author.name, "Author1")
+
+        self.assertEqual(len(ctx.captured_queries), 0)
+
+    async def test_reverse_one_to_one(self):
+        async with self.capture() as ctx:
+            authors = await self.authors(
+                SelectRelatedAuthorModel.async_objects.prefetch_related(
+                    "profile"
+                )
+            )
+            bio = authors[0].profile.bio
+
+        self.assertEqual(bio, "Bio1")
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_missing_reverse_one_to_one_raises_without_a_query(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.prefetch_related("profile")
+        )
+
+        async with self.capture() as ctx:
+            with self.assertRaises(
+                SelectRelatedAuthorModel.profile.RelatedObjectDoesNotExist
+            ):
+                authors[1].profile
+
+        self.assertEqual(len(ctx.captured_queries), 0)
+
+    async def test_reverse_many_relation_preserves_custom_ordering(self):
+        books = SelectRelatedBookModel.async_objects.order_by("-title")
+
+        async with self.capture() as ctx:
+            authors = await self.authors(
+                SelectRelatedAuthorModel.async_objects.prefetch_related(
+                    Prefetch("books", queryset=books)
+                )
+            )
+
+        related_books = await self.evaluate(authors[0].books.all())
+        self.assertEqual(
+            [book.title for book in related_books], ["Book2", "Book1"]
+        )
+        self.assertIn("ORDER BY", ctx.captured_queries[1]["sql"])
+
+    async def test_reverse_one_to_one_custom_queryset_to_attr(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.prefetch_related(
+                Prefetch(
+                    "profile",
+                    queryset=SelectRelatedProfileModel.async_objects.none(),
+                    to_attr="prefetched_profile",
+                )
+            )
+        )
+
+        self.assertIsNone(authors[0].prefetched_profile)
+        self.assertIsNone(authors[1].prefetched_profile)
+
+
+class TestPrefetchRelatedManyToMany(PrefetchRelatedTestCase):
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        through = M2MOwnerModel.tags.through
+        self.owner1 = await M2MOwnerModel.async_objects.acreate(name="Owner1")
+        self.owner2 = await M2MOwnerModel.async_objects.acreate(name="Owner2")
+        self.tag1 = await M2MTagModel.async_objects.acreate(name="Tag1")
+        self.tag2 = await M2MTagModel.async_objects.acreate(name="Tag2")
+        await through.async_objects.acreate(
+            m2mownermodel=self.owner1, m2mtagmodel=self.tag1
+        )
+        await through.async_objects.acreate(
+            m2mownermodel=self.owner1, m2mtagmodel=self.tag2
+        )
+
+    async def test_forward_many_to_many(self):
+        async with self.capture() as ctx:
+            owners = await self.evaluate(
+                M2MOwnerModel.async_objects.prefetch_related("tags").order_by(
+                    "name"
+                )
+            )
+            tags = [
+                sorted(tag.name for tag in owner.tags.all())
+                for owner in owners
+            ]
+
+        self.assertEqual(tags, [["Tag1", "Tag2"], []])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_reverse_many_to_many(self):
+        async with self.capture() as ctx:
+            tags = await self.evaluate(
+                M2MTagModel.async_objects.prefetch_related("owners").order_by(
+                    "name"
+                )
+            )
+            owners = [
+                sorted(owner.name for owner in tag.owners.all())
+                for tag in tags
+            ]
+
+        self.assertEqual(owners, [["Owner1"], ["Owner1"]])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_forward_many_to_many_to_attr_conflicts_with_field(self):
+        queryset = M2MOwnerModel.async_objects.prefetch_related(
+            Prefetch(
+                "tags",
+                queryset=M2MTagModel.async_objects.all(),
+                to_attr="tags",
+            )
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            await self.evaluate(queryset)
+        self.assertEqual(
+            str(ctx.exception),
+            "to_attr=tags conflicts with a field on the M2MOwnerModel model.",
+        )
+
+    async def test_reverse_many_to_many_to_attr_conflicts_with_field(self):
+        queryset = M2MTagModel.async_objects.prefetch_related(
+            Prefetch(
+                "owners",
+                queryset=M2MOwnerModel.async_objects.all(),
+                to_attr="owners",
+            )
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            await self.evaluate(queryset)
+        self.assertEqual(
+            str(ctx.exception),
+            "to_attr=owners conflicts with a field on the M2MTagModel model.",
+        )
+
+    async def test_forward_many_to_many_sliced_queryset(self):
+        owners = await self.evaluate(
+            M2MOwnerModel.async_objects.order_by("name").prefetch_related(
+                Prefetch(
+                    "tags",
+                    queryset=M2MTagModel.async_objects.order_by("name")[:1],
+                    to_attr="first_tag",
+                )
+            )
+        )
+
+        self.assertEqual([tag.name for tag in owners[0].first_tag], ["Tag1"])
+        self.assertEqual(owners[1].first_tag, [])
+
+    async def test_reverse_many_to_many_sliced_queryset(self):
+        tags = await self.evaluate(
+            M2MTagModel.async_objects.order_by("name").prefetch_related(
+                Prefetch(
+                    "owners",
+                    queryset=M2MOwnerModel.async_objects.order_by("name")[:1],
+                    to_attr="first_owner",
+                )
+            )
+        )
+
+        self.assertEqual(
+            [[owner.name for owner in tag.first_owner] for tag in tags],
+            [["Owner1"], ["Owner1"]],
+        )
+
+
+class TestPrefetchRelatedNestedLookups(PrefetchRelatedTestCase):
+
+    async def test_nested_lookup_uses_three_queries(self):
+        async with self.capture() as ctx:
+            authors = await self.authors(
+                SelectRelatedAuthorModel.async_objects.prefetch_related(
+                    "books__publisher"
+                )
+            )
+            publishers = sorted(
+                "" if book.publisher is None else book.publisher.name
+                for book in authors[0].books.all()
+            )
+
+        self.assertEqual(publishers, ["", "Publisher1"])
+        self.assertEqual(len(ctx.captured_queries), 3)
+
+    async def test_overlapping_lookups_are_deduplicated(self):
+        async with self.capture() as ctx:
+            books = await self.books(
+                SelectRelatedBookModel.async_objects.prefetch_related(
+                    "author", "author__profile"
+                )
+            )
+            bios = [book.author.profile.bio for book in books]
+
+        self.assertEqual(bios, ["Bio1", "Bio1"])
+        self.assertEqual(len(ctx.captured_queries), 3)
+
+    async def test_select_related_relation_is_not_prefetched_again(self):
+        async with self.capture() as ctx:
+            books = await self.books(
+                SelectRelatedBookModel.async_objects.select_related(
+                    "author"
+                ).prefetch_related("author__profile")
+            )
+            bios = [book.author.profile.bio for book in books]
+
+        self.assertEqual(bios, ["Bio1", "Bio1"])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_to_attr_can_be_traversed_by_later_lookup(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.prefetch_related(
+                Prefetch("books", to_attr="library"),
+                "library__publisher",
+            )
+        )
+
+        self.assertEqual(
+            [
+                book.publisher.name if book.publisher else None
+                for book in authors[0].library
+            ],
+            ["Publisher1", None],
+        )
+
+    async def test_nested_prefetch_on_custom_queryset_is_not_overwritten(self):
+        books = SelectRelatedBookModel.async_objects.prefetch_related(
+            "publisher"
+        )
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.prefetch_related(
+                Prefetch("books", queryset=books)
+            )
+        )
+
+        async with self.capture() as ctx:
+            related_books = await self.evaluate(authors[0].books.all())
+            publishers = [book.publisher for book in related_books]
+
+        self.assertEqual(publishers, [self.publisher1, None])
+        self.assertEqual(len(ctx.captured_queries), 0)
+
+    async def test_nullable_relation_can_be_traversed(self):
+        books = await self.books(
+            SelectRelatedBookModel.async_objects.prefetch_related(
+                "publisher__books"
+            )
+        )
+
+        self.assertEqual(
+            [book.title for book in books[0].publisher.books.all()],
+            ["Book1"],
+        )
+        self.assertIsNone(books[1].publisher)
+
+
+class TestPrefetchObject(PrefetchRelatedTestCase):
+
+    async def test_prefetch_with_custom_queryset(self):
+        async with self.capture() as ctx:
+            authors = await self.authors(
+                SelectRelatedAuthorModel.async_objects.prefetch_related(
+                    Prefetch(
+                        "books",
+                        queryset=SelectRelatedBookModel.async_objects.filter(
+                            title="Book1"
+                        ),
+                    )
+                )
+            )
+            books = authors[0].books.all()
+            titles = list(books)
+
+        self.assertEqual([book.title for book in titles], ["Book1"])
+        self.assertEqual(len(books), 1)
+        self.assertTrue(books)
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_prefetch_to_attr(self):
+        async with self.capture() as ctx:
+            authors = await self.authors(
+                SelectRelatedAuthorModel.async_objects.prefetch_related(
+                    Prefetch(
+                        "books",
+                        queryset=SelectRelatedBookModel.async_objects.filter(
+                            title="Book2"
+                        ),
+                        to_attr="cheap_books",
+                    )
+                )
+            )
+
+        self.assertIsInstance(authors[0].cheap_books, list)
+        self.assertEqual(
+            [book.title for book in authors[0].cheap_books], ["Book2"]
+        )
+        self.assertEqual(authors[1].cheap_books, [])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_same_lookup_with_two_querysets_is_rejected(self):
+        queryset = SelectRelatedAuthorModel.async_objects.prefetch_related(
+            "books",
+            Prefetch(
+                "books",
+                queryset=SelectRelatedBookModel.async_objects.all(),
+            ),
+        )
+
+        with self.assertRaises(ValueError):
+            await self.authors(queryset)
+
+    async def test_custom_queryset_can_be_sliced(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.prefetch_related(
+                Prefetch(
+                    "books",
+                    queryset=SelectRelatedBookModel.async_objects.order_by(
+                        "title"
+                    )[1:],
+                    to_attr="later_books",
+                )
+            )
+        )
+
+        self.assertEqual(
+            [book.title for book in authors[0].later_books], ["Book2"]
+        )
+        self.assertEqual(authors[1].later_books, [])
+
+
+class TestPrefetchRelatedEvaluationPaths(PrefetchRelatedTestCase):
+
+    async def test_afirst_applies_the_prefetch(self):
+        async with self.capture() as ctx:
+            book = (
+                await SelectRelatedBookModel.async_objects.order_by("title")
+                .prefetch_related("author")
+                .afirst()
+            )
+            name = book.author.name
+
+        self.assertEqual(name, "Author1")
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_aget_applies_the_prefetch(self):
+        async with self.capture() as ctx:
+            author = (
+                await SelectRelatedAuthorModel.async_objects.filter(
+                    name="Author1"
+                )
+                .prefetch_related("books")
+                .aget()
+            )
+            titles = sorted(book.title for book in author.books.all())
+
+        self.assertEqual(titles, ["Book1", "Book2"])
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_slicing_applies_the_prefetch(self):
+        async with self.capture() as ctx:
+            books = await self.evaluate(
+                SelectRelatedBookModel.async_objects.order_by(
+                    "title"
+                ).prefetch_related("author")[:1]
+            )
+            name = books[0].author.name
+
+        self.assertEqual(name, "Author1")
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_acount_does_not_trigger_the_prefetch(self):
+        async with self.capture() as ctx:
+            count = (
+                await SelectRelatedBookModel.async_objects.prefetch_related(
+                    "author"
+                ).acount()
+            )
+
+        self.assertEqual(count, 2)
+        self.assertEqual(len(ctx.captured_queries), 1)
+
+    async def test_prefetch_runs_only_once_per_queryset(self):
+        queryset = SelectRelatedBookModel.async_objects.prefetch_related(
+            "author"
+        )
+        await self.evaluate(queryset)
+
+        async with self.capture() as ctx:
+            await self.evaluate(queryset)
+
+        self.assertEqual(len(ctx.captured_queries), 0)
+
+
+class TestAprefetchRelatedObjects(PrefetchRelatedTestCase):
+
+    async def test_prefetches_already_loaded_instances(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.all()
+        )
+
+        async with self.capture() as ctx:
+            await aprefetch_related_objects(authors, "books")
+            titles = sorted(book.title for book in authors[0].books.all())
+
+        self.assertEqual(titles, ["Book1", "Book2"])
+        self.assertEqual(len(ctx.captured_queries), 1)
+
+    async def test_second_call_is_a_no_op(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.all()
+        )
+        await aprefetch_related_objects(authors, "books")
+
+        async with self.capture() as ctx:
+            await aprefetch_related_objects(authors, "books")
+
+        self.assertEqual(len(ctx.captured_queries), 0)
+
+    async def test_empty_instance_list_is_a_no_op(self):
+        async with self.capture() as ctx:
+            await aprefetch_related_objects([], "books")
+
+        self.assertEqual(len(ctx.captured_queries), 0)
+
+    async def test_accepts_various_iterables(self):
+        author = await SelectRelatedAuthorModel.async_objects.filter(
+            name="Author1"
+        ).aget()
+
+        class AuthorIterable:
+            def __iter__(self):
+                yield author
+
+        cases = (
+            (author,),
+            deque([author]),
+            {author},
+            frozenset([author]),
+            {"author": author}.values(),
+            AuthorIterable(),
+        )
+        for instances in cases:
+            with self.subTest(iterable=type(instances).__name__):
+                author._prefetched_objects_cache = {}
+                async with self.capture() as ctx:
+                    await aprefetch_related_objects(instances, "books")
+                self.assertEqual(len(ctx.captured_queries), 1)
+                self.assertEqual(
+                    [book.title for book in author.books.all()],
+                    ["Book1", "Book2"],
+                )
+
+    async def test_second_call_fetches_new_instances(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.all()
+        )
+        await aprefetch_related_objects(authors[:1], "books")
+
+        async with self.capture() as ctx:
+            await aprefetch_related_objects(authors, "books")
+
+        self.assertEqual(len(ctx.captured_queries), 1)
+        self.assertEqual(list(authors[1].books.all()), [])
+
+    async def test_custom_filtered_queryset(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.all()
+        )
+
+        await aprefetch_related_objects(
+            authors,
+            Prefetch(
+                "books",
+                queryset=SelectRelatedBookModel.async_objects.filter(
+                    title="Book1"
+                ),
+            ),
+        )
+
+        books = list(authors[0].books.all())
+        self.assertEqual([book.title for book in books], ["Book1"])
+
+    async def test_nested_lookup_after_custom_queryset_prefetch(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.all()
+        )
+        await aprefetch_related_objects(
+            authors,
+            Prefetch(
+                "books",
+                queryset=SelectRelatedBookModel.async_objects.all(),
+            ),
+        )
+
+        async with self.capture() as ctx:
+            await aprefetch_related_objects(authors, "books__publisher")
+
+        books = list(authors[0].books.all())
+        self.assertEqual([book.title for book in books], ["Book1", "Book2"])
+        self.assertEqual(books[0].publisher, self.publisher1)
+        self.assertIsNone(books[1].publisher)
+        self.assertEqual(len(ctx.captured_queries), 1)
+
+    async def test_rejects_django_prefetch_with_clear_error(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.all()
+        )
+        msg = (
+            "Prefetch lookups must be strings. Use "
+            "django_async_backend.db.models.query.Prefetch instead of "
+            "django.db.models.Prefetch."
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            await aprefetch_related_objects(authors, DjangoPrefetch("books"))
+        self.assertEqual(str(ctx.exception), msg)
+
+    async def test_forward_foreign_key(self):
+        books = await self.books(SelectRelatedBookModel.async_objects.all())
+
+        async with self.capture() as ctx:
+            await aprefetch_related_objects(books, "author")
+            names = [book.author.name for book in books]
+
+        self.assertEqual(names, ["Author1", "Author1"])
+        self.assertEqual(len(ctx.captured_queries), 1)
+
+    async def test_reverse_one_to_one(self):
+        authors = await self.authors(
+            SelectRelatedAuthorModel.async_objects.all()
+        )
+
+        async with self.capture() as ctx:
+            await aprefetch_related_objects(authors, "profile")
+            bio = authors[0].profile.bio
+
+        self.assertEqual(bio, "Bio1")
+        self.assertEqual(len(ctx.captured_queries), 1)
+
+    async def test_many_to_many(self):
+        through = M2MOwnerModel.tags.through
+        owner = await M2MOwnerModel.async_objects.acreate(
+            name="StandaloneOwner"
+        )
+        tag = await M2MTagModel.async_objects.acreate(name="StandaloneTag")
+        await through.async_objects.acreate(
+            m2mownermodel=owner, m2mtagmodel=tag
+        )
+        owners = await self.evaluate(
+            M2MOwnerModel.async_objects.filter(pk=owner.pk)
+        )
+
+        async with self.capture() as ctx:
+            await aprefetch_related_objects(owners, "tags")
+            names = [related.name for related in owners[0].tags.all()]
+
+        self.assertEqual(names, ["StandaloneTag"])
+        self.assertEqual(len(ctx.captured_queries), 1)
+
+
+class TestPrefetchRelatedMultiDatabase(PrefetchRelatedTestCase):
+
+    async def test_using_is_honored_for_primary_and_related_queries(self):
+        author = await SelectRelatedAuthorModel.async_objects.using(
+            "other"
+        ).acreate(name="OtherAuthor")
+        await SelectRelatedBookModel.async_objects.using("other").acreate(
+            title="OtherBook", author=author
+        )
+
+        async with self.capture("other") as other_ctx:
+            authors = await self.evaluate(
+                SelectRelatedAuthorModel.async_objects.using("other")
+                .filter(name="OtherAuthor")
+                .prefetch_related("books")
+            )
+
+        self.assertEqual(
+            [book.title for book in authors[0].books.all()], ["OtherBook"]
+        )
+        self.assertEqual(len(other_ctx.captured_queries), 2)
+
+    async def test_custom_queryset_can_select_a_different_database(self):
+        author = await SelectRelatedAuthorModel.async_objects.using(
+            "other"
+        ).acreate(name="OtherAuthor")
+        await SelectRelatedBookModel.async_objects.using("other").acreate(
+            title="OtherBook", author=author
+        )
+        other_authors = await self.evaluate(
+            SelectRelatedAuthorModel.async_objects.using("other").filter(
+                name="OtherAuthor"
+            )
+        )
+
+        async with self.capture() as default_ctx:
+            await aprefetch_related_objects(
+                other_authors,
+                Prefetch(
+                    "books",
+                    queryset=SelectRelatedBookModel.async_objects.using(
+                        "default"
+                    ),
+                ),
+            )
+
+        self.assertEqual(await self.evaluate(other_authors[0].books.all()), [])
+        self.assertEqual(len(default_ctx.captured_queries), 1)
+
+
+class TestPrefetchRelatedMultiTableInheritance(PrefetchRelatedTestCase):
+
+    async def test_parent_link_can_be_prefetched(self):
+        child = await ChildModel.async_objects.acreate(
+            parent_value=1, child_value=2
+        )
+
+        async with self.capture() as ctx:
+            children = await self.evaluate(
+                ChildModel.async_objects.filter(pk=child.pk).prefetch_related(
+                    "parentmodel_ptr"
+                )
+            )
+            parent = children[0].parentmodel_ptr
+
+        self.assertEqual(parent.parent_value, 1)
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+    async def test_child_link_can_be_prefetched(self):
+        child = await ChildModel.async_objects.acreate(
+            parent_value=1, child_value=2
+        )
+
+        async with self.capture() as ctx:
+            parents = await self.evaluate(
+                ParentModel.async_objects.filter(pk=child.pk).prefetch_related(
+                    "childmodel"
+                )
+            )
+            fetched_child = parents[0].childmodel
+
+        self.assertEqual(fetched_child.child_value, 2)
+        self.assertEqual(len(ctx.captured_queries), 2)
+
+
+class TestPrefetchRelatedUnsupported(PrefetchRelatedTestCase):
+
+    async def test_generic_foreign_key_is_not_supported(self):
+        await GenericFkModel.async_objects.acreate(name="Generic")
+        queryset = GenericFkModel.async_objects.prefetch_related(
+            "content_object"
+        )
+
+        with self.assertRaises(NotSupportedError) as ctx:
+            await self.evaluate(queryset)
+
+        self.assertIn("content_object", str(ctx.exception))
+
+    async def test_generic_relation_is_not_supported(self):
+        """A GenericRelation never even reaches the prefetch dispatch: simply
+        building its related manager looks the ContentType up synchronously.
+        """
+        await GenericRelationModel.async_objects.acreate(name="Generic")
+        queryset = GenericRelationModel.async_objects.prefetch_related(
+            "children"
+        )
+
+        with self.assertRaises(SynchronousOnlyOperation):
+            await self.evaluate(queryset)
+
+    async def test_unknown_lookup_is_rejected(self):
+        queryset = SelectRelatedBookModel.async_objects.prefetch_related(
+            "does_not_exist"
+        )
+
+        with self.assertRaises(AttributeError) as ctx:
+            await self.books(queryset)
+
+        self.assertIn("does_not_exist", str(ctx.exception))
+
+    async def test_non_relational_lookup_is_rejected(self):
+        queryset = SelectRelatedBookModel.async_objects.prefetch_related(
+            "title"
+        )
+
+        with self.assertRaises(ValueError):
+            await self.books(queryset)
+
+
+class TestPrefetchRelatedLeavesNoCoroutineUnawaited(PrefetchRelatedTestCase):
+
+    async def test_no_unawaited_coroutine_warning(self):
+        """An unawaited coroutine only surfaces as a RuntimeWarning at
+        collection time, which does not fail a test on its own, so capture
+        warnings and force a collection while they are still recorded.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            books = await self.books(
+                SelectRelatedBookModel.async_objects.prefetch_related(
+                    "author", "publisher"
+                )
+            )
+            for book in books:
+                book.author.name
+
+            authors = await self.authors(
+                SelectRelatedAuthorModel.async_objects.prefetch_related(
+                    "books__publisher", "profile"
+                )
+            )
+            for author in authors:
+                list(author.books.all())
+
+            owners = await self.evaluate(
+                M2MOwnerModel.async_objects.prefetch_related("tags")
+            )
+            for owner in owners:
+                list(owner.tags.all())
+
+            await aprefetch_related_objects(authors, "books")
+
+            del books, authors, owners
+            gc.collect()
+
+        unawaited = sorted(
+            {
+                str(w.message).splitlines()[0]
+                for w in caught
+                if "never awaited" in str(w.message)
+            }
+        )
+
+        self.assertEqual(
+            unawaited,
+            [],
+            "prefetch_related() left a coroutine unawaited: %s" % unawaited,
+        )

--- a/tests/test_app/migrations/0007_prefetch_related_models.py
+++ b/tests/test_app/migrations/0007_prefetch_related_models.py
@@ -1,0 +1,122 @@
+import django.db.models.deletion
+from django.db import (
+    migrations,
+    models,
+)
+
+import django_async_backend.db.models.base
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("test_app", "0006_totalorderingcompositepkmodel"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SelectRelatedAuthorModel",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255, unique=True)),
+            ],
+            options={"db_table": "select_related_author_model"},
+            bases=(
+                django_async_backend.db.models.base.AsyncModelMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="SelectRelatedPublisherModel",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255, unique=True)),
+            ],
+            options={"db_table": "select_related_publisher_model"},
+            bases=(
+                django_async_backend.db.models.base.AsyncModelMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="SelectRelatedProfileModel",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("bio", models.CharField(max_length=255)),
+                (
+                    "author",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="profile",
+                        to="test_app.selectrelatedauthormodel",
+                    ),
+                ),
+            ],
+            options={"db_table": "select_related_profile_model"},
+            bases=(
+                django_async_backend.db.models.base.AsyncModelMixin,
+                models.Model,
+            ),
+        ),
+        migrations.CreateModel(
+            name="SelectRelatedBookModel",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("title", models.CharField(max_length=255, unique=True)),
+                (
+                    "author",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="books",
+                        to="test_app.selectrelatedauthormodel",
+                    ),
+                ),
+                (
+                    "publisher",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="books",
+                        to="test_app.selectrelatedpublishermodel",
+                    ),
+                ),
+            ],
+            options={"db_table": "select_related_book_model"},
+            bases=(
+                django_async_backend.db.models.base.AsyncModelMixin,
+                models.Model,
+            ),
+        ),
+    ]

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -611,3 +611,48 @@ class TotalOrderingChildModel(AsyncModelMixin, models.Model):
 
     class Meta:
         db_table = "total_ordering_child_model"
+
+
+class SelectRelatedAuthorModel(AsyncModelMixin, models.Model):
+    name = models.CharField(max_length=255, unique=True)
+
+    class Meta:
+        db_table = "select_related_author_model"
+
+
+class SelectRelatedProfileModel(AsyncModelMixin, models.Model):
+    author = models.OneToOneField(
+        SelectRelatedAuthorModel,
+        on_delete=models.CASCADE,
+        related_name="profile",
+    )
+    bio = models.CharField(max_length=255)
+
+    class Meta:
+        db_table = "select_related_profile_model"
+
+
+class SelectRelatedPublisherModel(AsyncModelMixin, models.Model):
+    name = models.CharField(max_length=255, unique=True)
+
+    class Meta:
+        db_table = "select_related_publisher_model"
+
+
+class SelectRelatedBookModel(AsyncModelMixin, models.Model):
+    title = models.CharField(max_length=255, unique=True)
+    author = models.ForeignKey(
+        SelectRelatedAuthorModel,
+        on_delete=models.CASCADE,
+        related_name="books",
+    )
+    publisher = models.ForeignKey(
+        SelectRelatedPublisherModel,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="books",
+    )
+
+    class Meta:
+        db_table = "select_related_book_model"


### PR DESCRIPTION
Add django_async_backend.db.models.prefetch, an async counterpart of Django's prefetch_one_level(). Django's descriptors build a *sync* queryset in get_prefetch_querysets() and, for single-valued relations, iterate it eagerly to populate the reverse cache -- neither works here, so each descriptor's logic is mirrored to return an unevaluated async queryset plus a post_evaluate() callback that does the cache bookkeeping the sync code did while iterating.

Supported relation shapes:

- forward FK and forward O2O (ForwardManyToOneDescriptor)
- reverse O2O (ReverseOneToOneDescriptor)
- reverse FK and M2M (related managers from related_descriptors)

GenericForeignKey and GenericRelation are not supported: their prefetch issues one query per content type and resolves ContentType rows synchronously. GenericForeignKey raises NotSupportedError; GenericRelation trips Django's async guard while building its related manager.

Also validate lookups eagerly so the common mistakes fail with a clear message instead of an obscure one at evaluation time:

- QuerySet.prefetch_related() rejects non-str, non-Prefetch lookups
- Prefetch() rejects non-str lookups and sync querysets

Both checks live in codemon/config/db__models__query.yaml, since query.py is generated.

<img width="778" height="484" alt="Screenshot From 2026-08-31 14-49-24" src="https://github.com/user-attachments/assets/d1912533-8457-4eae-a7c3-d3aa5ad2ca9f" />

## Summary by Sourcery

Enable asynchronous queryset prefetching for standard Django relationships while validating inputs and documenting unsupported generic relations.

New Features:
- Add async `prefetch_related()` support for forward and reverse foreign-key, one-to-one, and many-to-many relationships, including nested lookups and custom prefetch querysets.
- Expose `aprefetch_related_objects()` for asynchronously prefetching relationships on existing model instances.

Enhancements:
- Provide clear validation errors for invalid prefetch lookups and synchronous or incompatible querysets.
- Explicitly report generic foreign-key and generic-relation prefetching as unsupported.

Documentation:
- Update ORM support documentation to mark `prefetch_related()` as partially supported and document generic-relation limitations.

Tests:
- Add comprehensive coverage for relationship types, nested lookups, custom querysets, caching, evaluation paths, multiple databases, inheritance, unsupported relations, and coroutine handling.

Chores:
- Move async prefetch evaluation into a dedicated prefetch module and integrate it with the generated async queryset implementation.